### PR TITLE
Enable service worker and locally install polymer-cli

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,12 @@
         document.head.appendChild(e);
       }
     })();
+    // load pre-caching service worker
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function() {
+        navigator.serviceWorker.register('/service-worker.js');
+      });
+    }
   </script>
 
   <link rel="import" href="/src/ubuntu-tutorials-app.html">

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,19 @@
+{
+  "name": "tutorials.ubuntu.com",
+  "version": "1.0.0",
+  "dependencies": {
+    "polymer-cli": {
+      "version": "~0.17.0",
+      "dependencies": {
+        "polymer-build": {
+          "version": "~0.4.1",
+          "dependencies": {
+            "sw-precache": {
+              "version": "~4.3.0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "tutorials.ubuntu.com",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ubuntudesign/tutorials.ubuntu.com.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ubuntudesign/tutorials.ubuntu.com/issues"
+  },
+  "homepage": "https://tutorials.ubuntu.com",
+  "scripts": {
+    "polymer": "./node_modules/polymer-cli/bin/polymer.js",
+    "build": "./node_modules/polymer-cli/bin/polymer.js build"
+  },
+  "devDependencies": {
+    "polymer-cli": "^0.17.0"
+  }
+}


### PR DESCRIPTION
# WIP: DO NOT MERGE

Locally install Polymer and specify a nested dependency in shrinkwrap to upgrade `sw-precache`.
This fixes the service worker generation for Firefox, from the upstream PR here: https://github.com/GoogleChrome/sw-precache/pull/233

This can currently be installed and built by running:
 - `npm i`
 - `npm run build`

The `build/bundled/service-worker.js` file should contain `redirect: 'follow'` like this:
```
              return cache.add(new Request(cacheKey, {
                credentials: 'same-origin',
                redirect: 'follow'
              }));
```