### PR TITLE
Manually set correct categories to fix api

### DIFF
--- a/categories-events.json
+++ b/categories-events.json
@@ -1,19 +1,14 @@
 {
   "categories": {
-    "example": {
+    "snap": {
       "maincolor": "var(--paper-indigo-500)",
       "secondarycolor": "var(--paper-indigo-700)",
       "lightcolor": "var(--paper-indigo-300)"
     },
-    "another": {
+    "snapcraft": {
       "maincolor": "var(--paper-teal-500)",
       "secondarycolor": "var(--paper-teal-700)",
       "lightcolor": "var(--paper-teal-300)"
-    },
-    "unknown": {
-      "maincolor": "#444",
-      "secondarycolor": "#444",
-      "lightcolor": "#444"
     }
   },
   "events": {


### PR DESCRIPTION
The build tool does not seem to be updating these categories. This will
set them manually so that the API filess are correctly generated for each category.
(Make a `snapcraft-recent.json` rather than making a `example-recent.json`)