### PR TITLE
Remove website snap tutorial

### DIFF
--- a/config/google-documents
+++ b/config/google-documents
@@ -18,6 +18,3 @@
 
 # Snap a python application
 1cvXAZRkmKExNIOXMUQihQrd8dNZK6f8v4wk020NymuI
-
-# How to snap a website
-1DYiNIlrcnTG4_xdkVizcvHCPTVHtYa2iPe2Vuwo8n7w


### PR DESCRIPTION
We have been requested to remove the website snap for now, this just removes the ID from the build list.