### PR TITLE
Revert "Remove website snap tutorial"

### DIFF
--- a/config/google-documents
+++ b/config/google-documents
@@ -18,3 +18,6 @@
 
 # Snap a python application
 1cvXAZRkmKExNIOXMUQihQrd8dNZK6f8v4wk020NymuI
+
+# How to snap a website
+1DYiNIlrcnTG4_xdkVizcvHCPTVHtYa2iPe2Vuwo8n7w


### PR DESCRIPTION
This reverts the previous commit to remove the website snap tutorial, as requested by Didier.