### PR TITLE
add fixed-height to cards

### DIFF
--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -71,7 +71,7 @@
         text-decoration: none;
       }
       .summary {
-        margin-bottom: 4em;
+        height: 170px;
       }
       .meta {
         color: var(--secondary-text-color);


### PR DESCRIPTION
### Done
Fixed the issue where differing height content broke the display of the card

### QA
Check that the cards now display the same height, regardless of description. (You can edit the content in-browser to test)