### PR TITLE
fix for the difficulty indicator reversal

### DIFF
--- a/src/elements/difficulty-indicator.html
+++ b/src/elements/difficulty-indicator.html
@@ -13,8 +13,12 @@
         width: 75px;
       }
 
+      .difficulty-indicator__value--1 {
+        background-position-x: -60px;
+      }
+
       .difficulty-indicator__value--2 {
-        background-position-x: -15px;
+        background-position-x: -45px;
       }
 
       .difficulty-indicator__value--3 {
@@ -22,11 +26,11 @@
       }
 
       .difficulty-indicator__value--4 {
-        background-position-x: -45px;
+        background-position-x: -15px;
       }
 
       .difficulty-indicator__value--5 {
-        background-position-x: -60px;
+        background-position-x: -0px;
       }
     </style>
     <span class$="difficulty-indicator__value difficulty-indicator__value--[[difficulty]]">[[difficulty]] out of 5</span>


### PR DESCRIPTION
## Done
Fixed a display bug where the difficulty levels are reversed

## QA
`polymer serve`
Look at the cards, inspect the difficulty bars and see that they reflect the hidden text in the span.