### PR TITLE
Improve page loading and add HTML metadata

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "app-layout": "polymerelements/app-layout#^0.10.0",
+    "app-metadata": "^0.0.6",
     "app-route": "polymerelements/app-route#^0.9.1",
     "codelab-components": "https://github.com/googlecodelabs/codelab-components.git#^2.0.2",
     "date-fns": "^1.27.1",

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
 
   <title>Ubuntu tutorials</title>
 
-  <meta name="description" content="Ubuntu tutorials!">
   <meta name="theme-color" content="#dd4814">
 
   <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16" />

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -184,13 +184,6 @@
       pattern="/:event"
       data="{{routeData}}"></app-route>
 
-    <iron-ajax
-      auto
-      url="/api/codelabs.json"
-      handle-as="json"
-      on-response="_codelabsInfoHandler"
-      loading="{{isLoading}}"></iron-ajax>
-
     <div>
       <template is="dom-if" if="{{currentEvent.id}}">
         <header class="horizontal layout event-wrapper">
@@ -232,26 +225,24 @@
           <div class="flex"></div>
         </div>
         <div class="horizontal layout wrap">
-          <template is="dom-if" if="[[!isLoading]]">
-            <template is="dom-if" if="[[!isEmpty]]">
-              <template is="dom-repeat" items="[[filteredTutorials]]" sort="[[_getSortFunction(filterSort)]]">
-                <codelabs-card heading="[[item.title]]" summary="[[item.summary]]" category="[[item.category]]"
-                              difficulty="[[item.difficulty]]" duration="[[item.duration}}" tags="[[item.tags]]"
-                              updated="[[item.updated]]" url="[[item.url]]" currenturl="[[eventRoute.prefix]][[eventRoute.path]]"
-                              categoriesmap="[[categoriesmap]]"></codelabs-card>
-              </template>
+          <template is="dom-if" if="[[!isEmpty]]">
+            <template is="dom-repeat" items="[[filteredTutorials]]" sort="[[_getSortFunction(filterSort)]]">
+              <codelabs-card heading="[[item.title]]" summary="[[item.summary]]" category="[[item.category]]"
+                            difficulty="[[item.difficulty]]" duration="[[item.duration}}" tags="[[item.tags]]"
+                            updated="[[item.updated]]" url="[[item.url]]" currenturl="[[eventRoute.prefix]][[eventRoute.path]]"
+                            categoriesmap="[[categoriesmap]]"></codelabs-card>
             </template>
-            <template is="dom-if" if="[[isEmpty]]">
-              <div class="no-results">
-                <h2>Why not try widening your search?</h2>
-                <h3>You can do this by:</h3>
-                <ul>
-                  <li>Removing any filters</li>
-                  <li>Using individual words instead of phrases</li>
-                  <li>Trying a different spelling</li>
-                </ul>
-              </div>
-            </template>
+          </template>
+          <template is="dom-if" if="[[isEmpty]]">
+            <div class="no-results">
+              <h2>Why not try widening your search?</h2>
+              <h3>You can do this by:</h3>
+              <ul>
+                <li>Removing any filters</li>
+                <li>Using individual words instead of phrases</li>
+                <li>Trying a different spelling</li>
+              </ul>
+            </div>
           </template>
         </div>
       </div>
@@ -265,14 +256,11 @@
       is: 'codelabs-index',
 
       properties: {
+        categoriesmap: Object,
         codelabs: {
           type: Array,
-          value: function() {
-            return [];
-          },
           notify: true,
         },
-        categoriesmap: Object,
         eventsmap: Object,
         searchKeywords: {
           type: Array,
@@ -311,9 +299,7 @@
         },
         filteredTutorials: {
           type: Array,
-          value: [],
           notify: true,
-          computed: "_getFilteredTutorials(codelabs, searchKeywords, filterEvent, filterCategory, filterUser)",
         },
         isEmpty: {
           type: Boolean,
@@ -327,6 +313,10 @@
           notify: true,
         },
       },
+
+      observers: [
+        '_getFilteredTutorials(codelabs, searchKeywords, filterEvent, filterCategory, filterUser)',
+      ],
 
       attached: function() {
         this.fire('app-metadata', {
@@ -365,6 +355,9 @@
       },
 
       _getFilteredTutorials: function(tutorials, searchKeywords, currentEvent, currentCategory, currentUser) {
+        if (tutorials === null) {
+          return [];
+        }
         if (searchKeywords.length > 0) {
           tutorials = tutorials.filter(this._getSearchFilterFunction(searchKeywords));
         }
@@ -376,6 +369,7 @@
         ) {
           tutorials = tutorials.filter(this._getFilterFunction(currentEvent, currentCategory, currentUser));
         }
+        this.filteredTutorials = tutorials;
         return tutorials;
       },
 
@@ -458,24 +452,6 @@
         currentEvent.logo = eventsmap[eventID].logo;
         currentEvent.description = eventsmap[eventID].description;
         return currentEvent;
-      },
-
-      _codelabsInfoHandler: function(event) {
-        this.categoriesmap = event.detail.response["categories"];
-        this.eventsmap = event.detail.response["events"];
-        event.detail.response["codelabs"].forEach(function(codelab) {
-          // filter hidden items
-          if (codelab.tags.indexOf('hidden') !== -1) {
-            return;
-          }
-          this.push("codelabs", codelab);
-        }, this);
-
-        // Force a binding update. Officially recommended, really!
-        // https://www.polymer-project.org/1.0/docs/devguide/model-data#override-dirty-check
-        var codelabs = this.codelabs;
-        this.codelabs = [];
-        this.codelabs = codelabs;
       },
 
       _searchKeywords: function(searchString) {

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -328,6 +328,13 @@
         },
       },
 
+      attached: function() {
+        this.fire('app-metadata', {
+          title: 'Ubuntu tutorials',
+          description: 'This is the page description',
+        });
+      },
+
       _getSortFunction: function(sortOption) {
         switch(sortOption) {
           case 'updated-asc':

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -235,7 +235,7 @@
           <template is="dom-if" if="[[!isLoading]]">
             <template is="dom-if" if="[[!isEmpty]]">
               <template is="dom-repeat" items="[[filteredTutorials]]" sort="[[_getSortFunction(filterSort)]]">
-                <codelabs-card title="[[item.title]]" summary="[[item.summary]]" category="[[item.category]]"
+                <codelabs-card heading="[[item.title]]" summary="[[item.summary]]" category="[[item.category]]"
                               difficulty="[[item.difficulty]]" duration="[[item.duration}}" tags="[[item.tags]]"
                               updated="[[item.updated]]" url="[[item.url]]" currenturl="[[eventRoute.prefix]][[eventRoute.path]]"
                               categoriesmap="[[categoriesmap]]"></codelabs-card>

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -44,9 +44,6 @@
         width: 98%;
         -webkit-appearance: none;
       }
-      @media only screen and (min-width: 769px) {
-        margin-bottom: 3em;
-      }
       input[type="search"]:focus {
         border-color: var(--tertiary-text-color);
         color: var(--tertiary-text-color);

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -130,7 +130,7 @@
         });
         if (metadata !== []) {
           this.fire('app-metadata', {
-            title: `${metadata.title} | Ubuntu tutorials`,
+            title: metadata.title + ' | Ubuntu tutorials',
             description: metadata.summary,
           });
         }

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../bower_components/polymer/polymer.html">
 <link rel="import" href="../bower_components/app-route/app-route.html">
 <link rel="import" href="../bower_components/codelab-components/google-codelab-elements.html">
+<link rel="import" href="../bower_components/iron-ajax/iron-ajax.html">
 
 <dom-module id="codelabs-page">
   <template>
@@ -72,11 +73,6 @@
       loading="{{loading}}"
       on-response="_loadTutorial">
     </iron-ajax>
-    <iron-ajax
-      auto
-      url="/api/codelabs.json"
-      handle-as="json"
-      on-response="_codelabsInfoHandler"></iron-ajax>
     <div id="contentContainer"></div>
   </template>
 
@@ -99,9 +95,7 @@
         },
         codelabs: {
           type: Array,
-          value: function() {
-            return [];
-          },
+          notify: true,
         },
       },
 
@@ -112,7 +106,7 @@
 
       _onPageChange: function(slug) {
         if (slug) {
-          document.querySelector("#tutorialAjax").generateRequest();
+          this.$.tutorialAjax.generateRequest();
         }
       },
 
@@ -124,11 +118,14 @@
       },
 
       _updateMetadata: function() {
+        if (!this.codelabs) {
+          return;
+        }
         var currentUrl = this.routeData.codelab;
         var metadata = this.codelabs.find(function(metadata) {
           return metadata.url === currentUrl;
         });
-        if (metadata !== []) {
+        if (metadata !== undefined) {
           this.fire('app-metadata', {
             title: metadata.title + ' | Ubuntu tutorials',
             description: metadata.summary,
@@ -152,9 +149,9 @@
       },
 
       _loadTutorial: function(e, url) {
+        this._updateMetadata();
         const resp = e.detail.response;
         Polymer.dom(this.$.contentContainer).innerHTML = resp.replace(/CODELABURL/g, this.url);
-        this._updateMetadata();
       },
 
       _codelaburl: function(codelabpath) {

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -66,9 +66,9 @@
       tail="{{routeTail}}">
     </app-route>
     <iron-ajax
+      id="tutorialAjax"
       url="[[url]]/index.html"
       handle-as="text"
-      auto
       loading="{{loading}}"
       on-response="_loadTutorial">
     </iron-ajax>
@@ -96,7 +96,14 @@
 
       observers: [
         '_handleLoading(loading, url)',
+        '_onPageChange(routeData.codelab)',
       ],
+
+      _onPageChange: function(slug) {
+        if (slug) {
+          document.querySelector("#tutorialAjax").generateRequest();
+        }
+      },
 
       _handleLoading: function(loading) {
         if (loading !== true) {

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -72,6 +72,11 @@
       loading="{{loading}}"
       on-response="_loadTutorial">
     </iron-ajax>
+    <iron-ajax
+      auto
+      url="/api/codelabs.json"
+      handle-as="json"
+      on-response="_codelabsInfoHandler"></iron-ajax>
     <div id="contentContainer"></div>
   </template>
 
@@ -91,6 +96,12 @@
           type: Boolean,
           notify: true,
           value: false,
+        },
+        codelabs: {
+          type: Array,
+          value: function() {
+            return [];
+          },
         },
       },
 
@@ -112,9 +123,38 @@
         Polymer.dom(this.$.contentContainer).innerHTML = '';
       },
 
+      _updateMetadata: function() {
+        var currentUrl = this.routeData.codelab;
+        var metadata = this.codelabs.find(function(metadata) {
+          return metadata.url === currentUrl;
+        });
+        if (metadata !== []) {
+          this.fire('app-metadata', {
+            title: `${metadata.title} | Ubuntu tutorials`,
+            description: metadata.summary,
+          });
+        }
+      },
+
+      _codelabsInfoHandler: function(event) {
+        this.categoriesmap = event.detail.response["categories"];
+        this.eventsmap = event.detail.response["events"];
+        event.detail.response["codelabs"].forEach(function(codelab) {
+          this.push("codelabs", codelab);
+        }, this);
+
+        // Force a binding update. Officially recommended, really!
+        // https://www.polymer-project.org/1.0/docs/devguide/model-data#override-dirty-check
+        var codelabs = this.codelabs;
+        this.codelabs = [];
+        this.codelabs = codelabs;
+        this._updateMetadata();
+      },
+
       _loadTutorial: function(e, url) {
         const resp = e.detail.response;
         Polymer.dom(this.$.contentContainer).innerHTML = resp.replace(/CODELABURL/g, this.url);
+        this._updateMetadata();
       },
 
       _codelaburl: function(codelabpath) {

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -122,9 +122,9 @@
           return;
         }
         var currentUrl = this.routeData.codelab;
-        var metadata = this.codelabs.find(function(metadata) {
+        var metadata = this.codelabs.filter(function(metadata) {
           return metadata.url === currentUrl;
-        });
+        })[0];
         if (metadata !== undefined) {
           this.fire('app-metadata', {
             title: metadata.title + ' | Ubuntu tutorials',

--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -40,7 +40,7 @@
         color: #fff;
         border-radius: 2px 2px 0 0;
       }
-      .title {
+      .heading {
         margin: 10px 0 0;
         font-family: 'Ubuntu',Helvetica,Arial;
         font-size: 28px;
@@ -101,7 +101,7 @@
           <div class="horizontal end-justified layout">
             <div class="light card-category">[[firstcategory]]</div>
           </div>
-          <h2 class="title">[[title]]</h2>
+          <h2 class="heading">[[heading]]</h2>
         </div>
         <div class="card-content">
           <p class="meta"><time-pretty datetime="[[updated]]">[[updated]]</time-pretty></p>
@@ -131,8 +131,8 @@
       ],
 
       properties: {
-        title: String,
         summary: String,
+        heading: String,
         category: Array,
         firstcategory: {
           type: String,

--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -6,7 +6,6 @@
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../bower_components/paper-card/paper-card.html">
 
-<link rel="import" href="codelabs-behaviors.html">
 <link rel="import" href="difficulty-indicator.html">
 <link rel="import" href="time-pretty.html">
 
@@ -126,10 +125,6 @@
 
       is: 'codelabs-card',
 
-      behaviors: [
-        Polymer.ColorByCategoryBehavior,
-      ],
-
       properties: {
         summary: String,
         heading: String,
@@ -154,11 +149,6 @@
 
       _extractFirstCategory: function(category) {
         var firstcategory = category[0];
-        var colors = this._colors_by_category(firstcategory, this.categoriesmap);
-        this.customStyle['--category-color'] = colors.maincolor;
-        this.customStyle['--category-secondary'] = colors.secondarycolor;
-        this.customStyle['--category-light'] = colors.lightcolor;
-        this.updateStyles();
         return firstcategory;
       },
 

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -54,9 +54,12 @@
     </tutorials-app-header>
 
     <iron-pages role="main" selected="[[page]]" attr-for-selected="name">
-      <codelabs-index name="codelabs-index" current-search=[[currentsearch]]></codelabs-index>
-      <codelabs-index name="events" event-route="[[subroute]]" current-search=[[currentsearch]]></codelabs-index>
-      <codelabs-page name="tutorial" route="[[subroute]]"></codelabs-page>
+      <section name="index">
+        <codelabs-index id="page-index" route="[[subroute]]" current-search=[[currentsearch]]></codelabs-index>
+      </section>
+      <section name="tutorial">
+        <codelabs-page id="page-tutorial" route="[[subroute]]"></codelabs-page>
+      </section>
     </iron-pages>
 
   </template>
@@ -69,33 +72,39 @@
         page: {
           type: String,
           reflectToAttribute: true,
-          observer: '_pageChanged'
         },
       },
 
       observers: [
-        '_routePageChanged(routeData.page)'
+        '_loadPage(routeData.page)',
       ],
 
       attached: function() {
         Polymer.AppMetadata.requestAvailability();
       },
 
-      _routePageChanged: function(page) {
-        this.page = page || 'codelabs-index';
-      },
-
-      _pageChanged: function(page) {
+      _loadPage: function _loadPage(page) {
         // load page import on demand.
+        page = page || 'index';
         var pageToLoad = page;
-        if (page == "events") {
-          pageToLoad = "codelabs-index";
+        if (page == 'index' || page == 'events') {
+          page = 'index';
+          pageToLoad = 'codelabs-index';
         }
-        if (page == "tutorial") {
-          pageToLoad = "codelabs-page";
+        if (page == 'tutorial') {
+          pageToLoad = 'codelabs-page';
         }
+
+        if (Polymer.isInstance(this.$['page-' + page])) {
+          this.page = page;
+          return;
+        }
+
+        var hrefToImport = this.resolveUrl(pageToLoad + '.html');
         this.importHref(
-          this.resolveUrl(pageToLoad + '.html'), null, null, true);
+          hrefToImport,
+          function loadPage() {this.page = page;}
+        );
       },
 
       _isMainHeaderHidden: function(page) {

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -7,6 +7,7 @@
 <link rel="import" href="../bower_components/app-layout/app-header-layout/app-header-layout.html">
 <link rel="import" href="../bower_components/app-layout/app-toolbar/app-toolbar.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../bower_components/iron-ajax/iron-ajax.html">
 <link rel="import" href="../bower_components/iron-pages/iron-pages.html">
 <link rel="import" href="../bower_components/iron-selector/iron-selector.html">
 <link rel="import" href="../bower_components/iron-icons/iron-icons.html">
@@ -41,6 +42,14 @@
       }
     </style>
 
+    <iron-ajax
+      auto
+      url="/api/codelabs.json"
+      handle-as="json"
+      on-response="_codelabsInfoHandler"
+      last-response="{{_codelabsLastResponse}}"
+      loading="{{isLoading}}"></iron-ajax>
+
     <app-location route="{{route}}"></app-location>
     <app-route
         route="{{route}}"
@@ -55,10 +64,10 @@
 
     <iron-pages role="main" selected="[[page]]" attr-for-selected="name">
       <section name="index">
-        <codelabs-index id="page-index" route="[[subroute]]" current-search=[[currentsearch]]></codelabs-index>
+        <codelabs-index id="page-index" route="[[subroute]]" current-search=[[currentsearch]] codelabs="{{codelabs}}"></codelabs-index>
       </section>
       <section name="tutorial">
-        <codelabs-page id="page-tutorial" route="[[subroute]]"></codelabs-page>
+        <codelabs-page id="page-tutorial" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-page>
       </section>
     </iron-pages>
 
@@ -69,6 +78,11 @@
       is: 'ubuntu-tutorials-app',
 
       properties: {
+        _codelabsLastResponse: Object,
+        codelabs: {
+          type: Array,
+          notify: true,
+        },
         page: {
           type: String,
           reflectToAttribute: true,
@@ -109,6 +123,27 @@
 
       _isMainHeaderHidden: function(page) {
         return page === "tutorial";
+      },
+
+      _codelabsInfoHandler: function(event) {
+        var codelabs = [];
+        if (this.codelabs !== undefined) {
+          codelabs = this.codelabs;
+        }
+        this.categoriesmap = event.detail.response["categories"];
+        this.eventsmap = event.detail.response["events"];
+        event.detail.response["codelabs"].forEach(function(codelab) {
+          // filter hidden items
+          if (codelab.tags.indexOf('hidden') !== -1) {
+            return;
+          }
+          codelabs.push(codelab);
+        }, this);
+
+        // Force a binding update. Officially recommended, really!
+        // https://www.polymer-project.org/1.0/docs/devguide/model-data#override-dirty-check
+        this.codelabs = [];
+        this.codelabs = codelabs;
       },
 
     });

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="../bower_components/app-metadata/app-metadata.html">
 <link rel="import" href="../bower_components/app-route/app-location.html">
 <link rel="import" href="../bower_components/app-route/app-route.html">
 <link rel="import" href="../bower_components/app-layout/app-drawer-layout/app-drawer-layout.html">
@@ -75,6 +76,10 @@
       observers: [
         '_routePageChanged(routeData.page)'
       ],
+
+      attached: function() {
+        Polymer.AppMetadata.requestAvailability();
+      },
 
       _routePageChanged: function(page) {
         this.page = page || 'codelabs-index';


### PR DESCRIPTION
This does a couple of changes to improve the site for search engine crawling.
Some changes are specifically aimed at the prerender.io service.

The commits show a better breakdown but here is a list:
- Pages (index / tutorial) correctly lazy load as needed and dependencies are separated.
- Tutorials API content is moved to main app file to share data and run alongside page loads.
- Page title and description is successfully updated on Tutorial pages.


## QA
Some slightly awkward steps, sorry!

- Clone https://github.com/prerender/prerender
  - In a background terminal: `npm i` prerender dependencies and run with `node server.js`
- (back in this repo) `bower i` to get latest dependencies.
- Generate example content with `./bin/generate examples`
- `polymer build`
- Start server `polymer serve -p 8083 build/bundled`
- Check out that the local site works nicely at http://localhost:8083
- Check prerender output (Javascript will not work, and styling will mostly be fine):
  - http://localhost:3000/http://localhost:8083/
  - http://localhost:3000/http://localhost:8083/tutorial/example (It is important that the page title and tutorial content should be available in HTML. The header seems to show in browser and I couldn't stop it.)
