### PR TITLE
Add websocket connection for live refresh on local server

### DIFF
--- a/src/elements/websocket-reloader.html
+++ b/src/elements/websocket-reloader.html
@@ -1,0 +1,49 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+
+<dom-module id="websocket-reloader">
+
+  <script>
+
+    Polymer({
+
+      is: 'websocket-reloader',
+
+      properties: {
+        connectedOnce: false,
+      },
+
+      ready: function() {
+        this._reconnect()
+      },
+
+      // connect websocket and different handlers
+      _reconnect: function() {
+        var websocket = new WebSocket('ws://' + window.location.hostname + ':' + window.location.port + '/reload');
+        websocket.onopen = this._connected.bind(this);
+        websocket.onclose = this._disconnected.bind(this);
+        websocket.onmessage = this._onmessage.bind(this);
+      },
+
+      _onmessage: function (e) {
+        if (location.pathname.endsWith("/" + e.data)) {
+          location.reload();
+        }
+      },
+
+      _connected: function (e) {
+        this.connectedOnce = true;
+      },
+
+      _disconnected: function(e) {
+        if (!this.connectedOnce) {
+          return
+        }
+        // The reload endpoint has been disconnected, we are retrying in 2 seconds.
+        console.log("Refresh socket disconnected");
+        setTimeout(() => this._reconnect(), 2000);
+      },
+    });
+
+  </script>
+
+</dom-module>

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -12,6 +12,7 @@
 <link rel="import" href="../bower_components/paper-input/paper-input.html">
 
 <link rel="import" href="elements/tutorials-app-header.html">
+<link rel="import" href="elements/websocket-reloader.html">
 <link rel="import" href="codelabs-index.html">
 <link rel="import" href="codelabs-page.html">
 
@@ -45,6 +46,8 @@
         pattern="/:page"
         data="{{routeData}}"
         tail="{{subroute}}"></app-route>
+
+    <websocket-reloader></websocket-reloader>
 
     <tutorials-app-header hidden="[[_isMainHeaderHidden(page)]]">
     </tutorials-app-header>


### PR DESCRIPTION
The local server (run by bin/serve) enables working incrementally on local
files referred by a codelab.
Everytime a codelab is changed, the modification is picked, corresponding
codelab is rebuilt and a signal is sent to all connected websockets to refresh
the website for this or those codelabs. This refresh is filtered client-side
to match corresponding tutorial name in the url. If not, it's a no-op.
We do reconnect the socket if it was able to connect successfully once and
then was disconnected. The effect is that on production server which won't have
that feature, we attempt to connect once, fail, but don't retry.