### PR TITLE
Update documentation for markdown and `./run`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ The markdown is rendered by [Google's claat markdown parser](https://github.com/
 
 #### Where should I save the file?
 
-The build tool allows files to be saved in in a single folder. We have best practices in our repository to maintain consistency.
+The build tool allows files to be saved in a single folder. We have best practices in our repository to maintain consistency.
 
 Please save new markdown files in a folder inside `./tutorials`, and save images in an `images` subfolder.
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ The markdown is rendered by [Google's claat markdown parser](https://github.com/
 
 #### Where should I save the file?
 
+The build tool allows files to be saved in in a single folder. We have best practices in our repository to maintain consistency.
+
 Please save new markdown files in a folder inside `./tutorials`, and save images in an `images` subfolder.
 ```
 .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,60 @@
-# Contributing to Ubuntu tutorials
+# Contributing
 
-## Guidelines
+Issues, content and code contributions are all very appreciated. We ask that you read the relevant sections of this document before contributing.
 
-We are building tutorial guidelines in our [guidelines document](https://docs.google.com/document/d/1u5qmSNIcE8SjuAg6aKjTxOBGWIjBW0kYf01t4Dfw6-U/edit)
+
+## Issues
+
+When creating issues, please add as much information as you can and try to split it up into readable sections.
+
+Some example sections to include:
+ - Short summary
+ - Steps taken to produce the issue
+ - Current and expected result
+ - A screenshot to demonstrate the issue
+
+
+## Pull requests
+
+Please try to create simple commits with readable commit messages. Do split the work into smaller pull requests, rather than one big pull request.
+
+Some sections to include when creating a PR:
+ - Short summary of the work completed
+ - Steps to view and test visual or code changes
+ - Links to any relevant issues
+ - Screenshots to demonstrate the work
+
 
 ## Tutorial content
 
-### Google Doc
+We have created a [guidelines document](https://docs.google.com/document/d/1u5qmSNIcE8SjuAg6aKjTxOBGWIjBW0kYf01t4Dfw6-U/edit) which contains details on our practices and conventions.
 
-We are using Google Docs as sources for our tutorials. You can find how to create these documents at the [googlecodelabs/tools repository](https://github.com/googlecodelabs/tools). You can also visit the [official Codelab Formatting Guide](https://docs.google.com/document/d/18dnMdUJQaGKY1Tit_-fO1YOpOpAbA4hh0YDXQlCEjvA/edit?ts=574ec5d9), once you have joined [Google's Codelab Authors group](https://groups.google.com/forum/#!forum/codelab-authors).
+We support Google Docs as a source for our Tutorials but want to use Markdown content moving forward.
 
 
 ### Markdown
 
-We wish to use markdown as source files in the future. Formatting instructions can be found at the [Markdown parser's Github page](https://github.com/googlecodelabs/tools/tree/master/claat/parser/md).
+_If you find any bugs in Markdown rendering, please report them to [Ubuntu tutorial deployment repository](https://github.com/ubuntu/tutorial-deployment)_
+
+Our [Ubuntu tutorial guidelines](./examples/guidelines-snap-tutorials.md) markdown tutorial is inside the `examples` folder. This contains useful information and resources to creating new tutorials. You can view this tutorial in full by running the local server with example data and can use the source as a template to create new content.
+
+The markdown is rendered by [Google's claat markdown parser](https://github.com/googlecodelabs/tools/tree/master/claat/parser/md). More information can be found on their github page.
+
+#### Where should I save the file?
+
+Please save new markdown files in a folder inside `./tutorials`, and save images in an `images` subfolder.
+```
+.
+└── tutorials
+    └── new-tutorial-name
+        ├── images
+            └── example-image.png
+        └── new-tutorial-name.md
+```
+
+We are working on adding external repository support for Canonical maintained repositories.
+
+
+### Google Doc
+
+While Google Doc tutorials are being deprecated for this project, instructions on how to create these documents are available at [googlecodelabs/tools repository](https://github.com/googlecodelabs/tools). You can also visit the [official Codelab Formatting Guide](https://docs.google.com/document/d/18dnMdUJQaGKY1Tit_-fO1YOpOpAbA4hh0YDXQlCEjvA/edit?ts=574ec5d9), once you have joined [Google's Codelab Authors group](https://groups.google.com/forum/#!forum/codelab-authors).

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,5 +1,12 @@
 # Ubuntu tutorials
 
+## Dependency management
+
+We use Yarn and Bower to manage the project dependencies. Yarn manages back end tools, while Bower managed front end libraries.
+
+When updating NPM packages, please use `yarn add` rather than `npm install`. As this updates the `yarn.lock` file which we rely upon.
+
+
 ## Technology
 
 tutorials.ubuntu.com is built with Google's Polymer, using web components. You can find information about these at the following links:
@@ -8,27 +15,13 @@ tutorials.ubuntu.com is built with Google's Polymer, using web components. You c
 - https://www.webcomponents.org/community/articles/why-web-components
 
 
-## Adding tutorials
-Tutorials are built via Google Docs and we will be adding markdown support.
+### Our build tools
 
-### `codelabs` command
+Our tooling used to serve and generate this project is available at our [Ubuntu tutorial deployment repository](https://github.com/ubuntu/tutorial-deployment).
 
-We are using a binary built from the ubuntu/codelabs repository. This wraps Google's `claat` command (Look below for more information). The source code is at: https://github.com/ubuntu/codelabs/tree/master/tools/codelabs
+We also make use of a `./run` command that we generate with our [generator-canonical-webteam Yeoman generator](https://github.com/canonical-webteam/generator-canonical-webteam)
 
-To add a new document, use this command:
-```
-./codelab add [GOOGLE_DOC_ID]
-```
-Or it can update previously imported documents with:
-```
-./codelab update
-```
 
 ### Google's claat
 
 Underneath the `codelabs` command, we are using [Google's `claat`](https://github.com/googlecodelabs/tools/tree/master/claat). In that repository, you will find information on the tool and how to download it.
-
-Here is an example command to run from inside the `tools` folder. It will fetch and generate the Basic snap usage tutorial. It will generate the tutorial page itself but will not update the index listing.
-```
-./claat-linux-amd64 export -f ubuntu-template.html -o "../src/codelabs" --prefix "../../.." "10jai4vAduTxF0RQMUs-pqIRbMM9TXv9dgxjNDGkxduo"
-```

--- a/HACKING.md
+++ b/HACKING.md
@@ -19,8 +19,6 @@ tutorials.ubuntu.com is built with Google's Polymer, using web components. You c
 
 Our tooling used to serve and generate this project is available at our [Ubuntu tutorial deployment repository](https://github.com/ubuntu/tutorial-deployment).
 
-We also make use of a `./run` command that we generate with our [generator-canonical-webteam Yeoman generator](https://github.com/canonical-webteam/generator-canonical-webteam)
-
 
 ### Google's claat
 

--- a/README.md
+++ b/README.md
@@ -9,48 +9,8 @@ For technical details and help, go to [HACKING.md](HACKING.md)
 
 ## Running this site
 
-There are two primary ways to run this website locally. We recommend using the `./run` command, which runs the site through Docker. The site can also run directly on the system with our build tools and Polymer.
 
-
-### `./run` command
-
-
-#### Dependencies
-
-- Latest version of Docker
-
-
-#### Quick start
-
-Start up a local server which watches serves content from the `examples` folder:
-``` bash
-$ ./run
-```
-
- Start up a local server which watches a given file or folder for changes relative to the project root.
-``` bash
-./run serve [file or folder]
-```
-
-
-#### Usage
-
-- `./run`: Run local server with example content.
-- `./run serve [file or folder]`: Run server and watch a local file or folder.
-- `./run build`: Generate Tutorials and build live site.
-- `./run help`: Print help.
-
-NPM/Yarn scripts:
-- `./run yarn serve-live`: Run local server with live content.
-- `./run yarn build-site`: Build site to `build` folder.
-- `./run yarn build-tutorials`: Generate live tutorials.
-- `./run yarn polymer [args]`: Run a command through Polymer.
-
-
-### Running without Docker
-
-
-#### Dependencies
+### Dependencies
 
 - Yarn or NPM
 - Bower
@@ -64,7 +24,7 @@ $ bower install
 ```
 
 
-#### Quick start
+### Quick start
 
 Start up a local server which watches the `examples` folder:
 ``` bash
@@ -73,7 +33,7 @@ $ ./yarn run serve examples
 The `examples` in the command can be replaced with another path.
 
 
-#### Usage
+### Usage
 
 Scripts are set up through the `package.json` file and run through Yarn:
 

--- a/README.md
+++ b/README.md
@@ -2,61 +2,94 @@
 
 The Polymer application that runs <https://tutorials.ubuntu.com>.
 
-For guidelines and help on how to build tutorial content, go to [CONTRIBUTING.md](CONTRIBUTING.md)
+For anyone wishing to contribute work or file issues, please read [CONTRIBUTING.md](CONTRIBUTING.md).
 
-For more in depth information on how the site works, go to [HACKING.md](HACKING.md)
+For technical details and help, go to [HACKING.md](HACKING.md)
 
-## Local development
 
-You can run this project locally with [Polymer CLI](https://www.npmjs.com/package/polymer-cli).
+## Running this site
 
-### Dependencies
+There are two primary ways to run this website locally. We recommend using the `./run` command, which runs the site through Docker. The site can also run directly on the system with our build tools and Polymer.
 
+
+### `./run` command
+
+
+#### Dependencies
+
+- Latest version of Docker
+
+
+#### Quick start
+
+Start up a local server which watches serves content from the `examples` folder:
 ``` bash
-npm install -g polymer-cli bower  # Install Polymer and Bower
-bower install                     # Pull down Bower dependencies
+$ ./run
 ```
 
-## Viewing Your Application
-
-```
-$ polymer serve
-```
-
-## Importing Codelabs
-
-Upon loading the website initially, you will likely be met with example content.
-To import live content, you will need to run:
-
-```
-$ ./bin/build-tutorials
+ Start up a local server which watches a given file or folder for changes relative to the project root.
+``` bash
+./run serve [file or folder]
 ```
 
-This will import the defined Google Doc IDs from the config folder.
 
-If you encounter an auth error, trying to import with this command should give you instructions on getting the token.
+#### Usage
 
+- `./run`: Run local server with example content.
+- `./run serve [file or folder]`: Run server and watch a local file or folder.
+- `./run build`: Generate Tutorials and build live site.
+- `./run help`: Print help.
+
+NPM/Yarn scripts:
+- `./run yarn serve-live`: Run local server with live content.
+- `./run yarn build-site`: Build site to `build` folder.
+- `./run yarn build-tutorials`: Generate live tutorials.
+- `./run yarn polymer [args]`: Run a command through Polymer.
+
+
+### Running without Docker
+
+
+#### Dependencies
+
+- Yarn or NPM
+- Bower
+
+(`npm` can be used in place of `yarn` in this document.)
+
+Install NPM and Bower dependencies:
+``` bash
+$ yarn install
+$ bower install
 ```
-$ ./tools/codelabs add [GOOGLE_DOC_ID]
+
+
+#### Quick start
+
+Start up a local server which watches the `examples` folder:
+``` bash
+$ ./yarn run serve examples
 ```
+The `examples` in the command can be replaced with another path.
+
+
+#### Usage
+
+Scripts are set up through the `package.json` file and run through Yarn:
+
+- `yarn run serve [file or folder]`: Run server and watch a local file or folder.
+- `yarn run build`: Generate Tutorials and build live site.
+- `yarn run serve-live`: Run local server with live content.
+- `yarn run build-site`: Build site to `build` folder.
+- `yarn run build-tutorials`: Generate live tutorials.
+- `yarn run polymer [args]`: Run a command through Polymer.
 
 
 ## Building Your Application
 
-```
-$ polymer build
-```
-
-This will create a `build/` folder with `bundled/` and `unbundled/` sub-folders
+Running the build command will generate a `build/` folder with `bundled/` and `unbundled/` sub-folders
 containing a bundled (Vulcanized) and unbundled builds, both run through HTML,
 CSS, and JS optimizers.
-
-You can serve the built versions by giving `polymer serve` a folder to serve
-from:
-
-```
-$ polymer serve build/bundled/app
-```
 
 ---
 


### PR DESCRIPTION
## Please do review this but the ./run command addition is not ready just yet

Update the documentation to simplify and make it much clearer how to contribute.
I am thinking about further improvements to the Issues and PR sections but I think this is a good starting point.