### PR TITLE
Use a new published keyword instead of updated

### DIFF
--- a/bin/build-api-feeds
+++ b/bin/build-api-feeds
@@ -78,8 +78,8 @@ def build_api(source, destination):
     tutorials = process_tutorials(parsed_data['tutorials'])
     events = process_events(parsed_data['events'])
 
-    # Sort tutorials by updated key, descending
-    tutorials = sorted(tutorials, key=itemgetter('updated'), reverse=True)
+    # Sort tutorials by published key, descending
+    tutorials = sorted(tutorials, key=itemgetter('published'), reverse=True)
 
     # Create standard recent.json
     write_json_file(tutorials, destination)

--- a/examples/guidelines-snap-tutorials.md
+++ b/examples/guidelines-snap-tutorials.md
@@ -5,6 +5,7 @@ categories: snapcraft
 tags: tutorial,guidelines,snap
 difficulty: 2
 status: Published
+Published: 2017-01-13
 
 ---
 
@@ -18,6 +19,7 @@ Remember that tags are searchable as well.
 
 Difficulty spans from 1 to 5. Beginners without previous knowledge from a topic should be able to take and understands tutorials from level 1 without any other prerequisites.
 
+Published is a date in YYYY-MM-DD format. Bump it for any major updates you are doing to the tutorial. This will put it as one of the first elements on the website.
 
 Tutorial title is 5 words maximum.
 

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -224,7 +224,7 @@
             <template is="dom-repeat" items="[[filteredTutorials]]" sort="[[_getSortFunction(filterSort)]]">
               <codelabs-card heading="[[item.title]]" summary="[[item.summary]]" category="[[item.category]]"
                             difficulty="[[item.difficulty]]" duration="[[item.duration}}" tags="[[item.tags]]"
-                            updated="[[item.updated]]" url="[[item.url]]" currenturl="[[eventRoute.prefix]][[eventRoute.path]]"
+                            published="[[item.published]]" url="[[item.url]]" currenturl="[[eventRoute.prefix]][[eventRoute.path]]"
                             categoriesmap="[[categoriesmap]]"></codelabs-card>
             </template>
           </template>
@@ -280,7 +280,7 @@
         },
         filterSort: {
           type: String,
-          value: 'updated-desc',
+          value: 'published-desc',
           notify: true,
         },
         filterUser: {
@@ -322,13 +322,13 @@
 
       _getSortFunction: function(sortOption) {
         switch(sortOption) {
-          case 'updated-asc':
+          case 'published-asc':
             return function(a, b) {
-              return a.updated > b.updated;
+              return a.published > b.published;
             };
-          case 'updated-desc':
+          case 'published-desc':
             return function(a, b) {
-              return a.updated < b.updated;
+              return a.published < b.published;
             };
           case 'duration-asc':
             return function(a, b) {

--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -102,7 +102,7 @@
           <h2 class="heading">[[heading]]</h2>
         </div>
         <div class="card-content">
-          <p class="meta"><time-pretty datetime="[[updated]]">[[updated]]</time-pretty></p>
+          <p class="meta"><time-pretty datetime="[[published]]">[[published]]</time-pretty></p>
           <p class="summary">[[summary]]</p>
           <div class="horizontal start-justified layout meta">
             <div class="difficulty">
@@ -135,7 +135,7 @@
         difficulty: Number,
         duration: Number,
         tags: Array,
-        updated: {
+        published: {
           type: String,
         },
         url: String,

--- a/src/elements/tutorials-filters.html
+++ b/src/elements/tutorials-filters.html
@@ -151,8 +151,8 @@
         sortOptions: {
           type: Object,
           value: {
-            'updated-desc': 'Newest first',
-            'updated-asc': 'Oldest first',
+            'published-desc': 'Newest first',
+            'published-asc': 'Oldest first',
             'duration-asc': 'Shortest first',
             'duration-desc': 'Longest first',
             'difficulty-desc': 'Most difficult first',


### PR DESCRIPTION
We moved in the claat tool from "updated" to a manually set "published" keyword. Setting it explicitely helps in particular on the markdown files, as creations and modifications time aren't kept when git cloning them.

That way, we control by updating the published key any creation and major updates. This is valid for both gdoc and markdown files.

* Updated read keys for website and external API parser
* Add it to the tutorial markdown example with some comments