### PR TITLE
Drop the snap-a-website tutorial

### DIFF
--- a/tutorials/gdoc.def
+++ b/tutorials/gdoc.def
@@ -19,8 +19,5 @@
 # Snap a python application
 1cvXAZRkmKExNIOXMUQihQrd8dNZK6f8v4wk020NymuI
 
-# How to snap a website
-1DYiNIlrcnTG4_xdkVizcvHCPTVHtYa2iPe2Vuwo8n7w
-
 # Advanced snap usage
 1V7dy86_gPW9GgCVL4j2LO0dWJogkzqFGm61IzbRoMZM


### PR DESCRIPTION
It's clunky and broken, using and showcasing technologies we don't support anymore.