### PR TITLE
Add linting, testing, and CI

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+bower_components/
+build/
+dist/
+node_modules/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,18 @@
+---
+extends: google
+plugins:
+  - html
+rules:
+  default-case: 0
+  indent: [2, 2, {"SwitchCase": 1}]
+  no-console: 0
+  no-inline-comments: 0
+  space-before-function-paren: [2, "never"]
+  require-jsdoc: 0
+globals:
+  '__dirname': false
+  'app': false
+  'page': false
+  'Polymer': false
+  'process': false
+  'require': false

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,8 @@
 extends: google
 plugins:
   - html
+parserOptions:
+  ecmaVersion: 6
 rules:
   default-case: 0
   indent: [2, 2, {"SwitchCase": 1}]
@@ -9,6 +11,9 @@ rules:
   no-inline-comments: 0
   space-before-function-paren: [2, "never"]
   require-jsdoc: 0
+  new-cap: [2, {
+      "capIsNewExceptions": ["Polymer"]
+    }]
 globals:
   '__dirname': false
   'app': false

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,5 @@
+bower_components/
+build/
+dist/
+node_modules/
+src/codelabs

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,4 +7,5 @@ rules:
   'block-closing-brace-newline-before': null
   'function-url-quotes': always
   'function-whitespace-after': null
+  'no-empty-source': null
   'string-quotes': single

--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -1,0 +1,10 @@
+extends:
+  - 'stylelint-config-polymer'
+processors:
+  - 'stylelint-processor-html'
+rules:
+  'block-closing-brace-newline-after': null
+  'block-closing-brace-newline-before': null
+  'function-url-quotes': always
+  'function-whitespace-after': null
+  'string-quotes': single

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+- ./run test

--- a/index.html
+++ b/index.html
@@ -61,6 +61,5 @@
   <!-- End Google Tag Manager -->
 
   <ubuntu-tutorials-app></ubuntu-tutorials-app>
-
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "eslint-plugin-html": "^2.0.0",
     "npm-run-all": "^4.0.2",
     "polymer-cli": "^0.18.2",
-    "stylelint": "^7.7.1",
-    "stylelint-config-polymer": "0.0.1",
+    "stylelint": "7.13.0",
+    "stylelint-config-polymer": "^0.0.1",
     "stylelint-processor-html": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-tutorials": "./bin/generate",
     "clean": "rm -rf bower_components node_modules build",
     "lint-js": "eslint 'src/**/*.html'",
-    "lint-polymer": "polymer lint",
+    "lint-polymer": "polymer lint -i src/*.html -i src/elements/*",
     "lint-style": "npm-run-all lint-style-*",
     "lint-style-html": "stylelint 'src/**/*.html' --extract",
     "polymer": "./bin/polymer",

--- a/package.json
+++ b/package.json
@@ -15,16 +15,27 @@
     "build-site": "npm-run-all polymer-build",
     "build-tutorials": "./bin/generate",
     "clean": "rm -rf bower_components node_modules build",
+    "lint-js": "eslint 'src/**/*.html'",
+    "lint-polymer": "polymer lint",
+    "lint-style": "npm-run-all lint-style-*",
+    "lint-style-html": "stylelint 'src/**/*.html' --extract",
     "polymer": "./bin/polymer",
     "polymer-build": "npm-run-all 'polymer build {@}' --",
     "polymer-lint": "npm-run-all 'polymer lint {@}' --",
     "polymer-serve": "npm-run-all 'polymer serve {@}' --",
     "serve": "npm-run-all 'serve-examples {@}' --",
     "serve-examples": "./bin/serve $(if [ -z \"$*\" ]; then echo \"examples\"; fi)",
-    "serve-live": "./bin/serve"
+    "serve-live": "./bin/serve",
+    "test": "npm-run-all lint-js lint-polymer lint-style"
   },
   "devDependencies": {
+    "eslint": "^3.14.1",
+    "eslint-config-google": "^0.7.1",
+    "eslint-plugin-html": "^2.0.0",
     "npm-run-all": "^4.0.2",
-    "polymer-cli": "^0.18.2"
+    "polymer-cli": "^0.18.2",
+    "stylelint": "^7.7.1",
+    "stylelint-config-polymer": "0.0.1",
+    "stylelint-processor-html": "^1.0.0"
   }
 }

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -15,18 +15,21 @@
       :host {
         display: block;
       }
+
       paper-tabs {
         --paper-tabs-selection-bar-color: var(--app-primary-color);
       }
+
       paper-tab {
         --paper-tab-ink: var(--app-primary-color);
       }
-      input[type="search"] {
+
+      input[type='search'] {
         background-color: white;
         border: 1px solid var(--color-mid-light);
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12) inset;
         box-sizing: border-box;
-        font-family: 'Ubuntu',Helvetica,Arial;
+        font-family: 'Ubuntu', Helvetica, Arial;
         font-size: 1em;
         font-weight: 300;
         line-height: 24px;
@@ -39,69 +42,84 @@
         width: 98%;
         -webkit-appearance: none;
       }
-      input[type="search"]:focus {
+
+      input[type='search']:focus {
         border-color: var(--tertiary-text-color);
         color: var(--tertiary-text-color);
       }
+
       paper-icon-button.search {
         color: var(--color-mid-light);
       }
+
       paper-icon-button.search:hover {
         color: var(--tertiary-text-color);
       }
+
       ::-webkit-input-placeholder { /* Chrome/Opera/Safari */
         color: var(--secondary-text-color);
       }
+
       ::-moz-placeholder { /* Firefox 19+ */
         color: var(--secondary-text-color);
       }
+
       :-ms-input-placeholder { /* IE 10+ */
         color: var(--secondary-text-color);
       }
+
       :-moz-placeholder { /* Firefox 18- */
         color: var(--secondary-text-color);
       }
+
       :focus::-webkit-input-placeholder { /* Chrome/Opera/Safari */
         color: var(--tertiary-text-color);
       }
+
       :focus::-moz-placeholder { /* Firefox 19+ */
         color: var(--tertiary-text-color);
       }
+
       :focus:-ms-input-placeholder { /* IE 10+ */
         color: var(--tertiary-text-color);
       }
+
       :focus:-moz-placeholder { /* Firefox 18- */
         color: var(--tertiary-text-color);
       }
+
       .content {
         margin: 0 auto;
         max-width: 980px;
-        padding-bottom: 90px;
-        padding-top: 50px;
         padding: 10px;
       }
+
       .intro {
         box-sizing: border-box;
         clear: both;
         display: block;
-        font-family: 'Ubuntu',Helvetica,Arial;
+        font-family: 'Ubuntu', Helvetica, Arial;
         height: 100%;
         overflow: hidden;
         padding: 0 10px 10px;
         position: relative;
         width: 100%;
       }
+
       .intro h1 {
         font-size: 2.8125em;
         font-weight: 300;
       }
+
       .intro p {
         font-weight: 300;
         max-width: 620px;
       }
+
       .intro a {
         color: var(--app-primary-color);
       }
+
       h2 {
         display: block;
         font-size: 1.625em;
@@ -110,6 +128,7 @@
         margin-bottom: 2.25em;
         width: 100%;
       }
+
       h3 {
         display: block;
         font-size: 1.4375em;
@@ -117,56 +136,70 @@
         line-height: 1.3;
         width: 100%;
       }
+
       .heading-results {
         margin-bottom: 1em;
       }
+
       @media only screen and (min-width: 768px) {
         .heading-results {
           margin-bottom: 1.75em;
         }
       }
+
       @media only screen and (min-width: 769px) {
         .heading-results {
           margin-bottom: 2em;
         }
       }
+
       .heading-results__highlight {
         font-weight: normal;
       }
+
       .no-results h2 {
         margin-bottom: 1em;
       }
+
       codelabs-card {
         margin: 10px;
       }
+
       @media only screen and (max-width: 768px) {
         codelabs-card {
           width: 100%;
         }
       }
+
       @media only screen and (min-width: 768px) {
         codelabs-card {
           width: 306px;
         }
       }
+
       .event-wrapper {
         background-color: white;
         padding: 10px;
       }
+
       .event-logo {
         min-width: 200px;
       }
+
       .event-description {
         margin-left: 20px;
       }
+
       a.codelabs-index {
         text-decoration: none;
       }
+
       a.codelabs-index:hover {
         text-decoration: underline;
       }
+
     .external {
-        background-image: url("https://assets.ubuntu.com/v1/f24a8aa0-external-link-orange.svg");
+        background-image: url('https://assets.ubuntu.com/v1/f24a8aa0-external-link-orange.svg');
         background-position: 100% top;
         background-repeat: no-repeat;
         background-size: 0.7em 0.7em;

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -175,7 +175,7 @@
     </style>
 
     <app-route
-      route="{{eventRoute}}"
+      route="{{route}}"
       pattern="/:event"
       data="{{routeData}}"></app-route>
 
@@ -224,8 +224,8 @@
             <template is="dom-repeat" items="[[filteredTutorials]]" sort="[[_getSortFunction(filterSort)]]">
               <codelabs-card heading="[[item.title]]" summary="[[item.summary]]" category="[[item.category]]"
                             difficulty="[[item.difficulty]]" duration="[[item.duration}}" tags="[[item.tags]]"
-                            published="[[item.published]]" url="[[item.url]]" currenturl="[[eventRoute.prefix]][[eventRoute.path]]"
-                            categoriesmap="[[categoriesmap]]"></codelabs-card>
+                            published="[[item.published]]" url="[[item.url]]" currenturl="[[route.prefix]][[route.path]]"
+                            ></codelabs-card>
             </template>
           </template>
           <template is="dom-if" if="[[isEmpty]]">
@@ -264,9 +264,9 @@
         },
         categories: {
           type: Array,
-          computed: "_buildcategories(categoriesmap)",
+          computed: '_buildcategories(categoriesmap)',
         },
-        eventRoute: String,
+        route: String,
         filterCategory: {
           type: String,
           value: '',
@@ -276,7 +276,7 @@
           type: Object,
           value: {},
           notify: true,
-          computed: "_eventChanged(routeData.event, eventsmap)"
+          computed: '_eventChanged(routeData.event, eventsmap)',
         },
         filterSort: {
           type: String,
@@ -302,6 +302,7 @@
           computed: '_isEmpty(filteredTutorials)',
         },
         isLoading: Boolean,
+        routeData: Object,
         searchResultCount: {
           type: Number,
           value: 0,
@@ -310,7 +311,7 @@
       },
 
       observers: [
-        '_getFilteredTutorials(codelabs, searchKeywords, filterEvent, filterCategory, filterUser)',
+        '_getFilteredTutorials(codelabs, searchKeywords, filterEvent, filterCategory, filterUser)', // eslint-disable-line
       ],
 
       attached: function() {
@@ -349,12 +350,16 @@
         };
       },
 
-      _getFilteredTutorials: function(tutorials, searchKeywords, currentEvent, currentCategory, currentUser) {
+      _getFilteredTutorials: function(
+        tutorials, searchKeywords, currentEvent, currentCategory, currentUser
+      ) {
         if (tutorials === null) {
           return [];
         }
         if (searchKeywords.length > 0) {
-          tutorials = tutorials.filter(this._getSearchFilterFunction(searchKeywords));
+          tutorials = tutorials.filter(
+            this._getSearchFilterFunction(searchKeywords)
+          );
         }
         this.searchResultCount = tutorials.length;
         if (
@@ -362,7 +367,9 @@
           currentCategory !== '' ||
           currentUser !== ''
         ) {
-          tutorials = tutorials.filter(this._getFilterFunction(currentEvent, currentCategory, currentUser));
+          tutorials = tutorials.filter(this._getFilterFunction(
+            currentEvent, currentCategory, currentUser
+          ));
         }
         this.filteredTutorials = tutorials;
         return tutorials;
@@ -370,44 +377,44 @@
 
       _getSearchFilterFunction: function(searchKeywords) {
         return function(item) {
-          var title = item.title.toLowerCase();
-          var summary = item.summary.toLowerCase();
-          var category = item.category[0].toLowerCase();
-          var tags = item.tags;
+          let title = item.title.toLowerCase();
+          let summary = item.summary.toLowerCase();
+          let category = item.category[0].toLowerCase();
+          let tags = item.tags;
 
-          var should_show = true;
+          let shouldShow = true;
           searchKeywords.forEach(function(searchterm) {
             if (searchterm === '') {
               return;
             }
             searchterm = searchterm.toLowerCase();
-            var searchterm_found = false;
+            let searchtermFound = false;
 
             if (
               title.indexOf(searchterm) > -1 ||
               summary.indexOf(searchterm) > -1 ||
               category.indexOf(searchterm) > -1
             ) {
-              searchterm_found = true;
+              searchtermFound = true;
               return;
             }
 
             tags.forEach(function(tag) {
               if (tag.toLowerCase().indexOf(searchterm) > -1) {
-                searchterm_found = true;
+                searchtermFound = true;
                 return;
               }
             }, this);
-            should_show = should_show && searchterm_found;
+            shouldShow = shouldShow && searchtermFound;
           }, this);
-          return should_show;
+          return shouldShow;
         };
       },
 
       _getFilterFunction: function(currentEvent, currentCategory, currentUser) {
         return function(item) {
-          var category = item.category[0].toLowerCase();
-          var tags = item.tags;
+          let category = item.category[0].toLowerCase();
+          let tags = item.tags;
 
           // filter by event matching
           if (currentEvent.id && tags.indexOf(currentEvent.id) < 0) {
@@ -432,17 +439,18 @@
       _eventChanged: function(eventID, eventsmap) {
         // FIXME (if upstream solution)
         // as we data-bind "subroute", even when not active, the view in map
-        // /codelabs/codelab_id -> codelab_id matches :events and return invalid content
+        // /codelabs/codelab_id -> codelab_id matches :events and
+        // return invalid content
         // escape if we are not current view
-        if (!this.classList.contains("iron-selected")) {
+        if (!this.classList.contains('iron-selected')) {
           return;
         }
-        if (eventID == "web") {
-          return {}
+        if (eventID == 'web') {
+          return {};
         }
-        var currentEvent = {
-          "id": eventID,
-        }
+        let currentEvent = {
+          'id': eventID,
+        };
         currentEvent.name = eventsmap[eventID].name;
         currentEvent.logo = eventsmap[eventID].logo;
         currentEvent.description = eventsmap[eventID].description;
@@ -451,15 +459,15 @@
 
       _searchKeywords: function(searchString) {
         if (searchString.length > 0) {
-          return searchString.split(" ");
+          return searchString.split(' ');
         }
         return [];
       },
 
       _buildcategories: function(categoriesmap) {
-        var newcategories = Object.keys(categoriesmap).sort();
-        newcategories.unshift("All");
-        var indexunknown = newcategories.indexOf("unknown");
+        let newcategories = Object.keys(categoriesmap).sort();
+        newcategories.unshift('All');
+        let indexunknown = newcategories.indexOf('unknown');
         if (indexunknown > -1) {
           newcategories.splice(indexunknown, 1);
         }

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -11,31 +11,37 @@
         --paper-blue-500: var(--secondary-color);
         --google-codelab-fab-background: var(--secondary-color);
       }
+
       :host {
         display: block;
         min-height: 100vh;
       }
+
       google-codelab-step {
         --google-codelab-step-code: {
-          font-family: 'Ubuntu Mono',Helvetica,Arial;
+          font-family: 'Ubuntu Mono', Helvetica, Arial;
         };
+
         --google-codelab-step-warn: {
-          border: 1px solid #ED3146;
+          border: 1px solid #ed3146;
           background: rgba(237, 49, 70, 0.1);
           color: #333;
         };
+
         --google-codelab-step-tip: {
-          border: 1px solid #ECA918;
+          border: 1px solid #eca918;
           background: rgba(236, 169, 24, 0.1);
           color: #333;
         };
       }
+
       #contentContainer google-codelab pre {
         background-color: var(--color-light);
         border-radius: 2px;
         border: 1px solid var(--color-mid-light);
         color: var(--color-dark);
       }
+
       #contentContainer google-codelab pre .str,
       #contentContainer google-codelab pre .kwd,
       #contentContainer google-codelab pre .com,
@@ -49,17 +55,21 @@
       #contentContainer google-codelab pre .dec {
         color: #333;
       }
+
       #contentContainer google-codelab-step::shadow .instructions {
         /* TODO: Move arrows down on smaller viewports */
-        /*margin-bottom: 96px;*/
+
+        /* margin-bottom: 96px; */
       }
+
       #contentContainer google-codelab-survey {
-        border: 1px solid #19B6EE;
+        border: 1px solid #19b6ee;
         background: rgba(25, 182, 238, 0.1);
         border-radius: 2px;
       }
+
       #contentContainer google-codelab p img {
-        /* Override images being forced at 100% width */
+        /*  Override images being forced at 100% width  */
         width: auto;
       }
     </style>

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -87,11 +87,13 @@
       properties: {
         url: {
           type: String,
-          computed: '_codelaburl(routeData.codelab)'
+          computed: '_codelaburl(routeData.codelab)',
         },
         route: {
           type: String,
         },
+        routeData: Object,
+        routeTail: String,
         loading: {
           type: Boolean,
           notify: true,
@@ -125,8 +127,8 @@
         if (!this.codelabs) {
           return;
         }
-        var currentUrl = this.routeData.codelab;
-        var metadata = this.codelabs.filter(function(metadata) {
+        let currentUrl = this.routeData.codelab;
+        let metadata = this.codelabs.filter(function(metadata) {
           return metadata.url === currentUrl;
         })[0];
         if (metadata !== undefined) {
@@ -138,15 +140,15 @@
       },
 
       _codelabsInfoHandler: function(event) {
-        this.categoriesmap = event.detail.response["categories"];
-        this.eventsmap = event.detail.response["events"];
-        event.detail.response["codelabs"].forEach(function(codelab) {
-          this.push("codelabs", codelab);
+        this.categoriesmap = event.detail.response['categories'];
+        this.eventsmap = event.detail.response['events'];
+        event.detail.response['codelabs'].forEach(function(codelab) {
+          this.push('codelabs', codelab);
         }, this);
 
         // Force a binding update. Officially recommended, really!
         // https://www.polymer-project.org/1.0/docs/devguide/model-data#override-dirty-check
-        var codelabs = this.codelabs;
+        let codelabs = this.codelabs;
         this.codelabs = [];
         this.codelabs = codelabs;
         this._updateMetadata();
@@ -155,7 +157,8 @@
       _loadTutorial: function(e, url) {
         this._updateMetadata();
         const resp = e.detail.response;
-        Polymer.dom(this.$.contentContainer).innerHTML = resp.replace(/CODELABURL/g, this.url);
+        let newHTML = resp.replace(/CODELABURL/g, this.url);
+        Polymer.dom(this.$.contentContainer).innerHTML = newHTML;
       },
 
       _codelaburl: function(codelabpath) {

--- a/src/elements/codelabs-behaviors.html
+++ b/src/elements/codelabs-behaviors.html
@@ -7,16 +7,16 @@
       categoriesmap: {
         type: Object,
         value: function() {
-          return {}
+          return {};
         },
       },
     },
 
     _colors_by_category: function(category, categoriesmap) {
-      var colors = categoriesmap[category];
+      let colors = categoriesmap[category];
       // set the unknown category in black
       if (!colors) {
-        colors = categoriesmap["unknown"];
+        colors = categoriesmap['unknown'];
       }
       return colors;
     },
@@ -24,7 +24,7 @@
   };
 
   Polymer.ColorByCategoryBehavior = [
-    Polymer.ColorByCategoryBehaviorImpl
+    Polymer.ColorByCategoryBehaviorImpl,
   ];
 
 </script>

--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -15,10 +15,12 @@
     <style include="iron-flex iron-flex-alignment">
       :host {
         display: inline-block;
+
         --category-secondary: #310824;
       }
+
       paper-card {
-        font-family: 'Ubuntu',Helvetica,Arial;
+        font-family: 'Ubuntu', Helvetica, Arial;
         height: 100%;
         position: relative;
 
@@ -26,10 +28,12 @@
           padding: 0;
         };
       }
+
       paper-card a {
         color: var(--primary-text-color);
         overflow: hidden;
       }
+
       .header {
         background: url('https://assets.ubuntu.com/v1/a88aa78c-card_background.png') no-repeat right bottom;
         background-size: cover;
@@ -38,18 +42,22 @@
         color: #fff;
         border-radius: 2px 2px 0 0;
       }
+
       .body {
-        margin: 0 16px 16px 16px;
+        margin: 0 16px 16px;
       }
+
       .heading {
         margin: 10px 0 0;
-        font-family: 'Ubuntu',Helvetica,Arial;
+        font-family: 'Ubuntu', Helvetica, Arial;
         font-size: 28px;
         font-weight: 300;
       }
+
       .light {
         color: white;
       }
+
       .card-category {
         text-align: left;
         text-transform: uppercase;
@@ -58,40 +66,49 @@
         left: 0;
         width: 100%;
       }
+
       .duration {
         text-align: right;
         width: 100%;
       }
+
       .card-actions {
         box-sizing: border-box;
         font-size: 1em;
         width: 100%;
         line-height: 2;
       }
+
       a {
         text-decoration: none;
       }
+
       .summary {
         height: 170px;
         margin: 0;
       }
+
       .meta {
         color: var(--secondary-text-color);
-        font-size: .875em;
+        font-size: 0.875em;
         white-space: nowrap;
       }
+
       .meta--tags {
         bottom: 0;
         padding-right: 10px;
         position: absolute;
       }
-      .meta--tags .meta__tag:after {
+
+      .meta--tags .meta__tag::after {
         content: ' ,';
         display: inline-block;
       }
-      .meta--tags .meta__tag:last-of-type:after {
+
+      .meta--tags .meta__tag:last-of-type::after {
         content: '';
       }
+
       .duration__value {
         color: var(--primary-text-color);
       }

--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -153,16 +153,16 @@
       },
 
       _extractFirstCategory: function(category) {
-        var firstcategory = category[0];
+        let firstcategory = category[0];
         return firstcategory;
       },
 
-      _generateBackParameter: function (currenturl) {
+      _generateBackParameter: function(currenturl) {
         if (currenturl) {
-            return "?backURL=" + encodeURIComponent(currenturl);
+          return '?backURL=' + encodeURIComponent(currenturl);
         }
-        return "";
-      }
+        return '';
+      },
 
     });
 

--- a/src/elements/difficulty-indicator.html
+++ b/src/elements/difficulty-indicator.html
@@ -30,7 +30,7 @@
       }
 
       .difficulty-indicator__value--5 {
-        background-position-x: -0px;
+        background-position-x: 0;
       }
     </style>
     <span class$="difficulty-indicator__value difficulty-indicator__value--[[difficulty]]">[[difficulty]] out of 5</span>

--- a/src/elements/time-pretty.html
+++ b/src/elements/time-pretty.html
@@ -16,7 +16,7 @@
       properties: {
         datetime: {
           type: String,
-          value: '0000-00-00T00:00:00.000Z'
+          value: '0000-00-00T00:00:00.000Z',
         },
         datetimePretty: {
           type: String,
@@ -24,12 +24,12 @@
         },
       },
 
-      _prettifyDatetime: function (datetime) {
+      _prettifyDatetime: function(datetime) {
         if (!window.dateFns) {
           return;
         }
-        var date = new Date(datetime);
-        var pretty = window.dateFns.format(date, 'DD MMMM YYYY');
+        let date = new Date(datetime);
+        let pretty = window.dateFns.format(date, 'DD MMMM YYYY');
         return pretty;
       },
 

--- a/src/elements/tutorials-app-header.html
+++ b/src/elements/tutorials-app-header.html
@@ -13,27 +13,33 @@
         color: white;
         padding: 0;
       }
+
       app-header-layout {
         z-index: 9999;
       }
+
       app-toolbar {
         margin: 0 auto;
         max-width: 984px;
         padding: 0;
         height: 48px;
       }
+
       .app-logo {
         margin-left: 10px;
       }
+
       @media only screen and (max-width: 984px) {
         .app-logo {
           margin-left: 20px;
         }
       }
+
       .app-logo a {
         color: #fff;
         text-decoration: none;
       }
+
       paper-input {
         --paper-input-container-focus-color: white;
         --paper-input-container-input-color: white;

--- a/src/elements/tutorials-filters.html
+++ b/src/elements/tutorials-filters.html
@@ -140,7 +140,7 @@
       is: 'tutorials-filters',
 
       properties: {
-        categoryOptions:  {
+        categoryOptions: {
           type: Object,
           value: {
             '': 'All topics',
@@ -183,6 +183,8 @@
           type: String,
           notify: true,
         },
+        showClear: Boolean,
+        showUsers: Boolean,
         isClearDisabled: {
           type: Boolean,
           computed: '_isClearDisabled(selectedCategory, selectedUser)',
@@ -190,16 +192,16 @@
       },
 
       _isClearDisabled: function(selectedCategory, selectedUser) {
-          return (selectedCategory.length === 0 && selectedUser.length === 0);
+        return (selectedCategory.length === 0 && selectedUser.length === 0);
       },
 
       _toArray: function(obj) {
-          return Object.keys(obj).map(function(key) {
-              return {
-                  name: obj[key],
-                  value: key,
-              };
-          });
+        return Object.keys(obj).map(function(key) {
+          return {
+            name: obj[key],
+            value: key,
+          };
+        });
       },
 
       _resetFilters: function() {

--- a/src/elements/tutorials-filters.html
+++ b/src/elements/tutorials-filters.html
@@ -13,19 +13,20 @@
       .filter-label {
         display: inline-block;
         float: left;
-        margin-right: .625rem;
+        margin-right: 0.625rem;
         margin-top: 7px;
         position: relative;
         width: auto;
       }
 
       paper-dropdown-menu {
-        --paper-input-container-focus-color: white;
-        font-family: 'Ubuntu',Helvetica,Arial;
+        font-family: 'Ubuntu', Helvetica, Arial;
         float: left;
         margin-right: 20px;
         margin-bottom: 1em;
         width: 100%;
+
+        --paper-input-container-focus-color: white;
 
         --paper-input-container: {
           background: white;
@@ -33,42 +34,51 @@
           box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12) inset;
           padding: 6px 10px;
         };
+
         --paper-input-container-input: {
           color: var(--primary-text-color);
-          font-family: 'Ubuntu',Helvetica,Arial;
+          font-family: 'Ubuntu', Helvetica, Arial;
           font-weight: 300;
           width: 100%;
           display: block;
         };
+
         --paper-input-container-label: {
           color: var(--primary-text-color);
           font-weight: 300;
         };
+
         --paper-input-container-underline: {
           display: none;
         };
       }
+
       @media only screen and (min-width: 768px) {
         paper-dropdown-menu {
           width: 228px;
         }
       }
+
       @media only screen and (min-width: 769px) {
         paper-dropdown-menu {
           width: auto;
         }
       }
+
       paper-menu-button {
         width: 100%;
       }
+
       .sort {
         float: right;
         margin-top: 40px;
         position: relative;
       }
+
       .sort paper-dropdown-menu {
         margin-right: 2px;
       }
+
       paper-button.button--primary {
         background: white;
         border: 1px solid var(--color-mid-light);
@@ -79,19 +89,21 @@
         text-transform: none;
         margin-left: 0;
       }
+
       paper-button.button--primary:hover {
         background: var(--color-light);
         border-color: var(--secondary-text-color);
       }
-      paper-button[disabled].button--primary {
-      }
+
       paper-listbox {
         padding: 0;
       }
+
       paper-item {
         font-weight: 300;
         width: 204px;
       }
+
       paper-item.iron-selected {
         font-weight: 300;
       }

--- a/src/elements/websocket-reloader.html
+++ b/src/elements/websocket-reloader.html
@@ -13,33 +13,33 @@
       },
 
       ready: function() {
-        this._reconnect()
+        this._reconnect();
       },
 
       // connect websocket and different handlers
       _reconnect: function() {
-        var websocket = new WebSocket('ws://' + window.location.hostname + ':' + window.location.port + '/reload');
+        let websocket = new WebSocket('ws://' + window.location.hostname + ':' + window.location.port + '/reload');
         websocket.onopen = this._connected.bind(this);
         websocket.onclose = this._disconnected.bind(this);
         websocket.onmessage = this._onmessage.bind(this);
       },
 
-      _onmessage: function (e) {
-        if (location.pathname.endsWith("/" + e.data)) {
+      _onmessage: function(e) {
+        if (location.pathname.endsWith('/' + e.data)) {
           location.reload();
         }
       },
 
-      _connected: function (e) {
+      _connected: function(e) {
         this.connectedOnce = true;
       },
 
       _disconnected: function(e) {
         if (!this.connectedOnce) {
-          return
+          return;
         }
         // The reload endpoint has been disconnected, we are retrying in 2 seconds.
-        console.log("Refresh socket disconnected");
+        console.log('Refresh socket disconnected');
         setTimeout(() => this._reconnect(), 2000);
       },
     });

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -9,6 +9,8 @@
 <link rel="import" href="elements/websocket-reloader.html">
 
 <dom-module id="ubuntu-tutorials-app">
+  <link rel="lazy-import" group="codelabs-index" href="codelabs-index.html">
+  <link rel="lazy-import" group="codelabs-page" href="codelabs-page.html">
 
   <template>
     <style>
@@ -54,7 +56,7 @@
 
     <iron-pages role="main" selected="[[page]]" attr-for-selected="name">
       <section name="index">
-        <codelabs-index id="page-index" route="[[subroute]]" current-search=[[currentsearch]] codelabs="{{codelabs}}"></codelabs-index>
+        <codelabs-index id="page-index" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-index>
       </section>
       <section name="tutorial">
         <codelabs-page id="page-tutorial" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-page>
@@ -73,10 +75,13 @@
           type: Array,
           notify: true,
         },
+        isLoading: Boolean,
         page: {
           type: String,
           reflectToAttribute: true,
         },
+        routeData: Object,
+        subroute: String,
       },
 
       observers: [
@@ -90,7 +95,7 @@
       _loadPage: function _loadPage(page) {
         // load page import on demand.
         page = page || 'index';
-        var pageToLoad = page;
+        let pageToLoad = page;
         if (page == 'index' || page == 'events') {
           page = 'index';
           pageToLoad = 'codelabs-index';
@@ -104,25 +109,27 @@
           return;
         }
 
-        var hrefToImport = this.resolveUrl(pageToLoad + '.html');
+        let hrefToImport = this.resolveUrl(pageToLoad + '.html');
         this.importHref(
           hrefToImport,
-          function loadPage() {this.page = page;}
+          function loadPage() {
+            this.page = page;
+          }
         );
       },
 
       _isMainHeaderHidden: function(page) {
-        return page === "tutorial";
+        return page === 'tutorial';
       },
 
       _codelabsInfoHandler: function(event) {
-        var codelabs = [];
+        let codelabs = [];
         if (this.codelabs !== undefined) {
           codelabs = this.codelabs;
         }
-        this.categoriesmap = event.detail.response["categories"];
-        this.eventsmap = event.detail.response["events"];
-        event.detail.response["codelabs"].forEach(function(codelab) {
+        this.categoriesmap = event.detail.response['categories'];
+        this.eventsmap = event.detail.response['events'];
+        event.detail.response['codelabs'].forEach(function(codelab) {
           // filter hidden items
           if (codelab.tags.indexOf('hidden') !== -1) {
             return;

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -27,9 +27,11 @@
         --color-mid-light: #cdcdcd;
         --color-dark: #333;
       }
+
       :host {
         display: block;
         line-height: 1.5;
+
         --category-color: white;
       }
     </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,6 +566,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
 ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
@@ -1545,6 +1551,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chalk@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
@@ -1648,9 +1662,19 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+color-convert@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
 color-diff@^0.1.3:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/color-diff/-/color-diff-0.1.7.tgz#6db78cd9482a8e459d40821eaf4b503283dcb8e2"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 colorguard@^1.2.0:
   version "1.2.0"
@@ -3139,6 +3163,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
 has@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
@@ -3201,9 +3229,9 @@ html-minifier@^3.0.1:
     relateurl "0.2.x"
     uglify-js "~2.8.22"
 
-html-tags@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-1.1.1.tgz#869f43859f12d9bdc3892419e494a628aa1b204e"
+html-tags@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
 
 htmlparser2@^3.8.2, htmlparser2@^3.9.1:
   version "3.9.2"
@@ -5836,7 +5864,7 @@ stylehacks@^2.3.2:
     text-table "^0.2.0"
     write-file-stdout "0.0.2"
 
-stylelint-config-polymer@0.0.1:
+stylelint-config-polymer@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/stylelint-config-polymer/-/stylelint-config-polymer-0.0.1.tgz#7db0683fc0d2477c7b7ce5cf3a3ac3d3df79d3c4"
 
@@ -5846,13 +5874,13 @@ stylelint-processor-html@^1.0.0:
   dependencies:
     htmlparser2 "^3.9.1"
 
-stylelint@^7.7.1:
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-7.11.0.tgz#4816372ecd0afd2c30fe53f4f6a00eb04960dbfc"
+stylelint@7.13.0:
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-7.13.0.tgz#111f97b6da72e775c80800d6bb6f5f869997785d"
   dependencies:
     autoprefixer "^6.0.0"
     balanced-match "^0.4.0"
-    chalk "^1.1.1"
+    chalk "^2.0.1"
     colorguard "^1.2.0"
     cosmiconfig "^2.1.1"
     debug "^2.6.0"
@@ -5862,7 +5890,7 @@ stylelint@^7.7.1:
     get-stdin "^5.0.0"
     globby "^6.0.0"
     globjoin "^0.1.4"
-    html-tags "^1.1.1"
+    html-tags "^2.0.0"
     ignore "^3.2.0"
     imurmurhash "^0.1.4"
     known-css-properties "^0.2.0"
@@ -5911,6 +5939,12 @@ supports-color@^3.2.3:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+supports-color@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
+  dependencies:
+    has-flag "^2.0.0"
 
 svg-tags@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,6 +468,13 @@
   dependencies:
     "@types/inquirer" "*"
 
+JSONStream@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.4.tgz#91657dfe6ff857483066132b4618b62e8f4887bd"
+  dependencies:
+    jsonparse "0.0.5"
+    through ">=2.2.7 <3"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -512,7 +519,11 @@ agent-base@2:
     extend "~3.0.0"
     semver "~5.0.1"
 
-ajv@^4.9.1:
+ajv-keywords@^1.0.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+
+ajv@^4.7.0, ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
   dependencies:
@@ -591,6 +602,12 @@ archiver@1.3.0:
     tar-stream "^1.5.0"
     walkdir "^0.0.11"
     zip-stream "^1.1.0"
+
+argparse@^1.0.7:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  dependencies:
+    sprintf-js "~1.0.2"
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -706,6 +723,17 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+autoprefixer@^6.0.0:
+  version "6.7.7"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
+  dependencies:
+    browserslist "^1.7.6"
+    caniuse-db "^1.0.30000634"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^5.2.16"
+    postcss-value-parser "^3.2.3"
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -714,7 +742,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.22.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -1281,7 +1309,7 @@ backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
 
-balanced-match@^0.4.1:
+balanced-match@^0.4.0, balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
@@ -1400,6 +1428,13 @@ browserify-zlib@^0.1.4:
   dependencies:
     pako "~0.2.0"
 
+browserslist@^1.1.1, browserslist@^1.1.3, browserslist@^1.7.6:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
+  dependencies:
+    caniuse-db "^1.0.30000639"
+    electron-to-chromium "^1.2.7"
+
 browserstack@^1.2.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/browserstack/-/browserstack-1.5.0.tgz#b565425ad62ed72c1082a1eb979d5313c7d4754f"
@@ -1433,9 +1468,19 @@ bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
 callsite@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 camel-case@3.0.x:
   version "3.0.0"
@@ -1458,6 +1503,10 @@ camelcase@^1.0.2:
 camelcase@^2.0.0, camelcase@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
+
+caniuse-db@^1.0.30000187, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
+  version "1.0.30000684"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000684.tgz#99acb0118b8fd1fdd601a15e0c0f2dfc15a81680"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1508,6 +1557,10 @@ chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
+circular-json@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
+
 class-extend@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/class-extend/-/class-extend-0.1.2.tgz#8057a82b00f53f82a5d62c50ef8cffdec6fabc34"
@@ -1556,6 +1609,13 @@ clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
 
+clone-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-1.0.0.tgz#eae0a2413f55c0942f818c229fefce845d7f3b1c"
+  dependencies:
+    is-regexp "^1.0.0"
+    is-supported-regexp-flag "^1.0.0"
+
 clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
@@ -1587,6 +1647,25 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+color-diff@^0.1.3:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/color-diff/-/color-diff-0.1.7.tgz#6db78cd9482a8e459d40821eaf4b503283dcb8e2"
+
+colorguard@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/colorguard/-/colorguard-1.2.0.tgz#f3facaf5caaeba4ef54653d9fb25bb73177c0d84"
+  dependencies:
+    chalk "^1.1.1"
+    color-diff "^0.1.3"
+    log-symbols "^1.0.2"
+    object-assign "^4.0.1"
+    pipetteur "^2.0.0"
+    plur "^2.0.0"
+    postcss "^5.0.4"
+    postcss-reporter "^1.2.1"
+    text-table "^0.2.0"
+    yargs "^1.2.6"
 
 colors@1.0.3, colors@1.0.x:
   version "1.0.3"
@@ -1684,7 +1763,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.7, concat-stream@^1.5.0:
+concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1734,6 +1813,18 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-2.1.3.tgz#952771eb0dddc1cb3fa2f6fbe51a522e93b3ee0a"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.1.0"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    require-from-string "^1.1.0"
+
 crc32-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-2.0.0.tgz#e3cdd3b4df3168dd74e3de3fbbcb7b297fe908f4"
@@ -1769,6 +1860,19 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
+css-color-names@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.3.tgz#de0cef16f4d8aa8222a320d5b6d7e9bbada7b9f6"
+
+css-rule-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/css-rule-stream/-/css-rule-stream-1.1.0.tgz#3786e7198983d965a26e31957e09078cbb7705a2"
+  dependencies:
+    css-tokenize "^1.0.1"
+    duplexer2 "0.0.2"
+    ldjson-stream "^1.2.1"
+    through2 "^0.6.3"
+
 css-slam@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/css-slam/-/css-slam-1.2.1.tgz#2467e5aecb7e989bd04f656011dd1cf8eb3e7165"
@@ -1777,6 +1881,13 @@ css-slam@^1.1.0:
     command-line-usage "^3.0.5"
     dom5 "^1.3.1"
     shady-css-parser "0.0.8"
+
+css-tokenize@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/css-tokenize/-/css-tokenize-1.0.1.tgz#4625cb1eda21c143858b7f81d6803c1d26fc14be"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^1.0.33"
 
 cssbeautify@^0.3.1:
   version "0.3.1"
@@ -1792,6 +1903,12 @@ cycle@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
 
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
+
 dargs@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-5.1.0.tgz#ec7ea50c78564cd36c9d5ec18f66329fade27829"
@@ -1806,7 +1923,7 @@ dateformat@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
 
-debug@2, debug@^2.0.0, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0:
+debug@2, debug@^2.0.0, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"
   dependencies:
@@ -1873,7 +1990,7 @@ define-properties@^1.1.2:
     foreach "^2.0.5"
     object-keys "^1.0.8"
 
-del@^2.2.2:
+del@^2.0.2, del@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
   dependencies:
@@ -1943,6 +2060,30 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
+doiuse@^2.4.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/doiuse/-/doiuse-2.6.0.tgz#1892d10b61a9a356addbf2b614933e81f8bb3834"
+  dependencies:
+    browserslist "^1.1.1"
+    caniuse-db "^1.0.30000187"
+    css-rule-stream "^1.1.0"
+    duplexer2 "0.0.2"
+    jsonfilter "^1.1.2"
+    ldjson-stream "^1.2.1"
+    lodash "^4.0.0"
+    multimatch "^2.0.0"
+    postcss "^5.0.8"
+    source-map "^0.4.2"
+    through2 "^0.6.3"
+    yargs "^3.5.4"
+
+dom-serializer@0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
 dom-urls@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/dom-urls/-/dom-urls-1.1.0.tgz#001ddf81628cd1e706125c7176f53ccec55d918e"
@@ -1969,11 +2110,38 @@ dom5@^2.0.0, dom5@^2.0.1, dom5@^2.1.0, dom5@^2.2.0, dom5@^2.3.0:
     clone "^2.1.0"
     parse5 "^2.2.2"
 
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
+domutils@^1.5.1:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
+
 dot-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
   dependencies:
     is-obj "^1.0.0"
+
+duplexer2@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
+  dependencies:
+    readable-stream "~1.1.9"
 
 duplexer2@^0.1.2, duplexer2@^0.1.4:
   version "0.1.4"
@@ -2019,6 +2187,10 @@ ee-first@1.1.1:
 ejs@^2.3.1:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.6.tgz#479636bfa3fe3b1debd52087f0acb204b4f19c88"
+
+electron-to-chromium@^1.2.7:
+  version "1.3.14"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz#64af0f9efd3c3c6acd57d71f83b49ca7ee9c4b43"
 
 encodeurl@~1.0.1:
   version "1.0.1"
@@ -2079,6 +2251,10 @@ engine.io@~1.8.4:
     engine.io-parser "1.3.2"
     ws "1.1.4"
 
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -2109,6 +2285,32 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.23"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.23.tgz#7578b51be974207a5487821b56538c224e4e7b38"
+  dependencies:
+    es6-iterator "2"
+    es6-symbol "~3.1"
+
+es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-symbol "^3.1"
+
+es6-map@^0.1.3:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-set "~0.1.5"
+    es6-symbol "~3.1.1"
+    event-emitter "~0.3.5"
+
 es6-promise@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-2.3.0.tgz#96edb9f2fdb01995822b263dd8aadab6748181bc"
@@ -2116,6 +2318,32 @@ es6-promise@^2.1.0:
 es6-promise@^4.0.5:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.0.tgz#dda03ca8f9f89bc597e689842929de7ba8cebdf0"
+
+es6-set@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-symbol "3.1.1"
+    event-emitter "~0.3.5"
+
+es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+es6-weak-map@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
 
 escape-html@1.0.1:
   version "1.0.1"
@@ -2140,6 +2368,65 @@ escodegen@^1.7.0:
   optionalDependencies:
     source-map "~0.2.0"
 
+escope@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+  dependencies:
+    es6-map "^0.1.3"
+    es6-weak-map "^2.0.1"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-config-google@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-google/-/eslint-config-google-0.7.1.tgz#5598f8498e9e078420f34b80495b8d959f651fb2"
+
+eslint-plugin-html@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-html/-/eslint-plugin-html-2.0.3.tgz#7c89883ab0c85fa5d28b666a14a4e906aa90b897"
+  dependencies:
+    htmlparser2 "^3.8.2"
+
+eslint@^3.14.1:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+  dependencies:
+    babel-code-frame "^6.16.0"
+    chalk "^1.1.3"
+    concat-stream "^1.5.2"
+    debug "^2.1.1"
+    doctrine "^2.0.0"
+    escope "^3.6.0"
+    espree "^3.4.0"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    glob "^7.0.3"
+    globals "^9.14.0"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
+    strip-json-comments "~2.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
 espree@^3.1.7, espree@^3.4.0:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
@@ -2151,13 +2438,34 @@ esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
+esprima@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.1.0.tgz#4713b6536adf7f2ac4f327d559e7756bff648220"
+  dependencies:
+    estraverse "~4.1.0"
+    object-assign "^4.0.1"
+
 estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
-estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+
+estraverse@~4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -2177,6 +2485,13 @@ etag@~1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051"
 
+event-emitter@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
 event-stream@~3.3.0:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
@@ -2192,6 +2507,12 @@ event-stream@~3.3.0:
 eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
+
+execall@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
+  dependencies:
+    clone-regexp "^1.0.0"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -2318,6 +2639,13 @@ figures@^1.3.5:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
 
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -2392,6 +2720,19 @@ first-chunk-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
   dependencies:
     readable-stream "^2.0.2"
+
+flat-cache@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.2.2.tgz#fa86714e72c21db88601761ecf2f555d1abc6b96"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
+
+flatten@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
 follow-redirects@0.0.7:
   version "0.0.7"
@@ -2472,6 +2813,10 @@ function-bind@^1.0.2, function-bind@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
+gather-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gather-stream/-/gather-stream-1.0.0.tgz#b33994af457a8115700d410f317733cbe7a0904b"
+
 generate-function@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"
@@ -2485,6 +2830,10 @@ generate-object-property@^1.1.0:
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stdin@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -2598,7 +2947,7 @@ global-prefix@^0.1.4:
     is-windows "^0.2.0"
     which "^1.2.12"
 
-globals@^9.0.0:
+globals@^9.0.0, globals@^9.14.0:
   version "9.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
 
@@ -2624,7 +2973,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-globby@^6.1.0:
+globby@^6.0.0, globby@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
   dependencies:
@@ -2633,6 +2982,10 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+globjoin@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
 
 got@^2.7.2:
   version "2.9.2"
@@ -2848,6 +3201,21 @@ html-minifier@^3.0.1:
     relateurl "0.2.x"
     uglify-js "~2.8.22"
 
+html-tags@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-1.1.1.tgz#869f43859f12d9bdc3892419e494a628aa1b204e"
+
+htmlparser2@^3.8.2, htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
 http-deceiver@^1.2.4:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
@@ -2905,6 +3273,10 @@ iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
+ignore@^3.2.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -2914,6 +3286,10 @@ indent-string@^2.1.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
   dependencies:
     repeating "^2.0.0"
+
+indexes-of@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
 
 indexof@0.0.1:
   version "0.0.1"
@@ -2941,6 +3317,24 @@ inherits@2.0.1:
 ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+inquirer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+  dependencies:
+    ansi-escapes "^1.1.0"
+    ansi-regex "^2.0.0"
+    chalk "^1.0.0"
+    cli-cursor "^1.0.1"
+    cli-width "^2.0.0"
+    figures "^1.3.5"
+    lodash "^4.3.0"
+    readline2 "^1.0.1"
+    run-async "^0.1.0"
+    rx-lite "^3.1.2"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
 
 inquirer@^1.0.2:
   version "1.2.3"
@@ -2979,6 +3373,10 @@ ipaddr.js@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.3.0.tgz#1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec"
 
+irregular-plurals@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.2.0.tgz#38f299834ba8c00c30be9c554e137269752ff3ac"
+
 is-absolute@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-0.1.7.tgz#847491119fccb5fb436217cc737f7faad50f603f"
@@ -3010,6 +3408,10 @@ is-date-object@^1.0.1:
 is-deflate@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-deflate/-/is-deflate-1.0.0.tgz#c862901c3c161fb09dac7cdc7e784f80e98f2f14"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-dotfile@^1.0.0:
   version "1.0.2"
@@ -3045,6 +3447,10 @@ is-fullwidth-code-point@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -3061,7 +3467,7 @@ is-gzip@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-gzip/-/is-gzip-1.0.0.tgz#6ca8b07b99c77998025900e555ced8ed80879a83"
 
-is-my-json-valid@^2.12.4:
+is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
   dependencies:
@@ -3130,9 +3536,19 @@ is-regex@^1.0.3:
   dependencies:
     has "^1.0.1"
 
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+
 is-relative@^0.1.0:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-0.1.3.tgz#905fee8ae86f45b3ec614bc3c15c869df0876e82"
+
+is-resolvable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
+  dependencies:
+    tryit "^1.0.1"
 
 is-retry-allowed@^1.0.0:
   version "1.1.0"
@@ -3141,6 +3557,10 @@ is-retry-allowed@^1.0.0:
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-supported-regexp-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz#8b520c85fae7a253382d4b02652e045576e13bb8"
 
 is-symbol@^1.0.1:
   version "1.0.1"
@@ -3198,9 +3618,20 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
+js-base64@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
+
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+
+js-yaml@^3.4.3, js-yaml@^3.5.1:
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^3.1.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -3236,9 +3667,22 @@ json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+jsonfilter@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/jsonfilter/-/jsonfilter-1.1.2.tgz#21ef7cedc75193813c75932e96a98be205ba5a11"
+  dependencies:
+    JSONStream "^0.8.4"
+    minimist "^1.1.0"
+    stream-combiner "^0.2.1"
+    through2 "^0.6.3"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+
+jsonparse@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-0.0.5.tgz#330542ad3f0a654665b778f3eb2d9a9fa507ac64"
 
 jsonpointer@^4.0.0:
   version "4.0.1"
@@ -3262,6 +3706,10 @@ kind-of@^3.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.0.tgz#b58abe4d5c044ad33726a8c1525b48cf891bff07"
   dependencies:
     is-buffer "^1.1.5"
+
+known-css-properties@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.2.0.tgz#899c94be368e55b42d7db8d5be7d73a4a4a41454"
 
 latest-version@^2.0.0:
   version "2.0.0"
@@ -3294,7 +3742,14 @@ lazystream@^1.0.0:
   dependencies:
     readable-stream "^2.0.5"
 
-levn@~0.3.0:
+ldjson-stream@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ldjson-stream/-/ldjson-stream-1.2.1.tgz#91beceda5ac4ed2b17e649fb777e7abfa0189c2b"
+  dependencies:
+    split2 "^0.2.1"
+    through2 "^0.6.1"
+
+levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
@@ -3419,11 +3874,11 @@ lodash@^3.0.0, lodash@^3.0.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.11.1, lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.8.0:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.8.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-log-symbols@^1.0.1:
+log-symbols@^1.0.1, log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
   dependencies:
@@ -3473,6 +3928,10 @@ map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
 
+mathml-tag-names@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.0.0.tgz#eee615112a2b127e70f558d69c9ebe14076503d7"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -3500,7 +3959,7 @@ mem-fs@^1.1.0:
     vinyl "^1.1.0"
     vinyl-file "^2.0.0"
 
-meow@^3.1.0, meow@^3.7.0:
+meow@^3.1.0, meow@^3.3.0, meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -3589,7 +4048,7 @@ minimist@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.0.tgz#cdf225e8898f840a258ded44fc91776770afdc93"
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3666,6 +4125,10 @@ multipipe@^1.0.2:
     duplexer2 "^0.1.2"
     object-assign "^4.1.0"
 
+mute-stream@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+
 mute-stream@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
@@ -3677,6 +4140,10 @@ mz@^2.4.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 ncname@1.0.x:
   version "1.0.0"
@@ -3742,6 +4209,14 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+
+normalize-selector@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/normalize-selector/-/normalize-selector-0.2.0.tgz#d0b145eb691189c63a78d201dc4fdb1293ef0c03"
+
 npm-run-all@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.0.2.tgz#a84669348e6db6ccbe052200b4cdb6bfe034a4fe"
@@ -3753,6 +4228,10 @@ npm-run-all@^4.0.2:
     read-pkg "^2.0.0"
     shell-quote "^1.6.1"
     string.prototype.padend "^3.0.0"
+
+num2fraction@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -3825,6 +4304,10 @@ once@~1.3.0:
   dependencies:
     wrappy "1"
 
+onecolor@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/onecolor/-/onecolor-3.0.4.tgz#75a46f80da6c7aaa5b4daae17a47198bd9652494"
+
 onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
@@ -3835,7 +4318,7 @@ opn@^3.0.2:
   dependencies:
     object-assign "^4.0.1"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -4050,6 +4533,13 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pipetteur@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pipetteur/-/pipetteur-2.0.3.tgz#1955760959e8d1a11cb2a50ec83eec470633e49f"
+  dependencies:
+    onecolor "^3.0.4"
+    synesthesia "^1.0.1"
+
 plist@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/plist/-/plist-2.1.0.tgz#57ccdb7a0821df21831217a3cad54e3e146a1025"
@@ -4057,6 +4547,16 @@ plist@^2.0.1:
     base64-js "1.2.0"
     xmlbuilder "8.2.2"
     xmldom "0.1.x"
+
+plur@^2.0.0, plur@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/plur/-/plur-2.1.2.tgz#7482452c1a0f508e3e344eaec312c91c29dc655a"
+  dependencies:
+    irregular-plurals "^1.0.0"
+
+pluralize@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
 plylog@^0.4.0:
   version "0.4.0"
@@ -4340,6 +4840,65 @@ polyserve@^0.19.0:
     spdy "^3.3.3"
     ua-parser-js "^0.7.12"
 
+postcss-less@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-0.14.0.tgz#c631b089c6cce422b9a10f3a958d2bedd3819324"
+  dependencies:
+    postcss "^5.0.21"
+
+postcss-media-query-parser@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+
+postcss-reporter@^1.2.1, postcss-reporter@^1.3.3:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-1.4.1.tgz#c136f0a5b161915f379dd3765c61075f7e7b9af2"
+  dependencies:
+    chalk "^1.0.0"
+    lodash "^4.1.0"
+    log-symbols "^1.0.2"
+    postcss "^5.0.0"
+
+postcss-reporter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-3.0.0.tgz#09ea0f37a444c5693878606e09b018ebeff7cf8f"
+  dependencies:
+    chalk "^1.0.0"
+    lodash "^4.1.0"
+    log-symbols "^1.0.2"
+    postcss "^5.0.0"
+
+postcss-resolve-nested-selector@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
+
+postcss-scss@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-0.4.1.tgz#ad771b81f0f72f5f4845d08aa60f93557653d54c"
+  dependencies:
+    postcss "^5.2.13"
+
+postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.1.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-value-parser@^3.1.1, postcss-value-parser@^3.2.3:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
+postcss@^5.0.0, postcss@^5.0.18, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.0.4, postcss@^5.0.8, postcss@^5.2.13, postcss@^5.2.16, postcss@^5.2.4:
+  version "5.2.17"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.17.tgz#cf4f597b864d65c8a492b2eabe9d706c879c388b"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -4364,7 +4923,7 @@ process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-progress@1.1.8:
+progress@1.1.8, progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
@@ -4474,6 +5033,12 @@ read-chunk@^2.0.0:
   dependencies:
     pify "^2.3.0"
 
+read-file-stdin@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/read-file-stdin/-/read-file-stdin-0.2.1.tgz#25eccff3a153b6809afacb23ee15387db9e0ee61"
+  dependencies:
+    gather-stream "^1.0.0"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -4504,7 +5069,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@1.1.x:
+readable-stream@1.1.x, readable-stream@^1.0.33, readable-stream@~1.1.9:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   dependencies:
@@ -4533,6 +5098,14 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     process-nextick-args "~1.0.6"
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
+
+readline2@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    mute-stream "0.0.5"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -4687,6 +5260,17 @@ request@^2.53.0, request@^2.72.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
+require-uncached@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
 requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -4697,6 +5281,14 @@ resolve-dir@^0.1.0:
   dependencies:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
 resolve@^1.0.0, resolve@^1.1.6:
   version "1.3.3"
@@ -4727,11 +5319,21 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
+run-async@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+  dependencies:
+    once "^1.3.0"
+
 run-async@^2.0.0, run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
+
+rx-lite@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
 rx@^4.1.0:
   version "4.1.0"
@@ -4888,7 +5490,7 @@ shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shelljs@^0.7.0:
+shelljs@^0.7.0, shelljs@^0.7.5:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
   dependencies:
@@ -4916,6 +5518,10 @@ sinon@^1.11.1:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 slide@^1.1.5:
   version "1.1.6"
@@ -4993,6 +5599,12 @@ source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+source-map@^0.4.2:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+  dependencies:
+    amdefine ">=0.0.4"
+
 source-map@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
@@ -5040,15 +5652,25 @@ spdy@^3.3.3:
     select-hose "^2.0.0"
     spdy-transport "^2.0.15"
 
+specificity@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.3.0.tgz#332472d4e5eb5af20821171933998a6bc3b1ce6f"
+
+split2@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-0.2.1.tgz#02ddac9adc03ec0bb78c1282ec079ca6e85ae900"
+  dependencies:
+    through2 "~0.6.1"
+
 split@0.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
   dependencies:
     through "2"
 
-sprintf-js@^1.0.3:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.0.tgz#cffcaf702daf65ea39bb4e0fa2b299cec1a1be46"
+sprintf-js@^1.0.3, sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
   version "1.13.0"
@@ -5080,6 +5702,13 @@ stacky@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
+stream-combiner@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.2.2.tgz#aec8cbac177b56b6f4fa479ced8c1912cee52858"
+  dependencies:
+    duplexer "~0.1.1"
+    through "~2.3.4"
+
 stream-combiner@~0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
@@ -5108,6 +5737,13 @@ string-width@^1.0.1:
   dependencies:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
+string-width@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
 
 string.prototype.padend@^3.0.0:
@@ -5180,6 +5816,86 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+style-search@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+
+stylehacks@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-2.3.2.tgz#64c83e0438a68c9edf449e8c552a7d9ab6009b0b"
+  dependencies:
+    browserslist "^1.1.3"
+    chalk "^1.1.1"
+    log-symbols "^1.0.2"
+    minimist "^1.2.0"
+    plur "^2.1.2"
+    postcss "^5.0.18"
+    postcss-reporter "^1.3.3"
+    postcss-selector-parser "^2.0.0"
+    read-file-stdin "^0.2.1"
+    text-table "^0.2.0"
+    write-file-stdout "0.0.2"
+
+stylelint-config-polymer@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/stylelint-config-polymer/-/stylelint-config-polymer-0.0.1.tgz#7db0683fc0d2477c7b7ce5cf3a3ac3d3df79d3c4"
+
+stylelint-processor-html@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-processor-html/-/stylelint-processor-html-1.0.0.tgz#6892b6b2855a45f0291cd845191d6908130a2918"
+  dependencies:
+    htmlparser2 "^3.9.1"
+
+stylelint@^7.7.1:
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-7.11.0.tgz#4816372ecd0afd2c30fe53f4f6a00eb04960dbfc"
+  dependencies:
+    autoprefixer "^6.0.0"
+    balanced-match "^0.4.0"
+    chalk "^1.1.1"
+    colorguard "^1.2.0"
+    cosmiconfig "^2.1.1"
+    debug "^2.6.0"
+    doiuse "^2.4.1"
+    execall "^1.0.0"
+    file-entry-cache "^2.0.0"
+    get-stdin "^5.0.0"
+    globby "^6.0.0"
+    globjoin "^0.1.4"
+    html-tags "^1.1.1"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    known-css-properties "^0.2.0"
+    lodash "^4.17.4"
+    log-symbols "^1.0.2"
+    mathml-tag-names "^2.0.0"
+    meow "^3.3.0"
+    micromatch "^2.3.11"
+    normalize-selector "^0.2.0"
+    pify "^2.3.0"
+    postcss "^5.0.20"
+    postcss-less "^0.14.0"
+    postcss-media-query-parser "^0.2.0"
+    postcss-reporter "^3.0.0"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-scss "^0.4.0"
+    postcss-selector-parser "^2.1.1"
+    postcss-value-parser "^3.1.1"
+    resolve-from "^3.0.0"
+    specificity "^0.3.0"
+    string-width "^2.0.0"
+    style-search "^0.1.0"
+    stylehacks "^2.3.2"
+    sugarss "^0.2.0"
+    svg-tags "^1.0.0"
+    table "^4.0.1"
+
+sugarss@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-0.2.0.tgz#ac34237563327c6ff897b64742bf6aec190ad39e"
+  dependencies:
+    postcss "^5.2.4"
+
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
@@ -5189,6 +5905,16 @@ supports-color@3.1.2:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
+  dependencies:
+    has-flag "^1.0.0"
+
+svg-tags@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
 
 sw-precache@^5.1.1:
   version "5.1.1"
@@ -5212,6 +5938,12 @@ sw-toolbox@^3.4.0:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
 
+synesthesia@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/synesthesia/-/synesthesia-1.0.1.tgz#5ef95ea548c0d5c6e6f9bb4b0d0731dff864a777"
+  dependencies:
+    css-color-names "0.0.3"
+
 table-layout@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-0.3.0.tgz#6ee20dc483db371b3e5c87f704ed2f7c799d2c9a"
@@ -5222,6 +5954,28 @@ table-layout@^0.3.0:
     feature-detect-es6 "^1.3.1"
     typical "^2.6.0"
     wordwrapjs "^2.0.0-0"
+
+table@^3.7.8:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+  dependencies:
+    ajv "^4.7.0"
+    ajv-keywords "^1.0.0"
+    chalk "^1.1.1"
+    lodash "^4.0.0"
+    slice-ansi "0.0.4"
+    string-width "^2.0.0"
+
+table@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.1.tgz#a8116c133fac2c61f4a420ab6cdf5c4d61f0e435"
+  dependencies:
+    ajv "^4.7.0"
+    ajv-keywords "^1.0.0"
+    chalk "^1.1.1"
+    lodash "^4.0.0"
+    slice-ansi "0.0.4"
+    string-width "^2.0.0"
 
 tar-fs@^1.12.0:
   version "1.15.2"
@@ -5277,7 +6031,7 @@ test-value@^2.1.0:
     array-back "^1.0.3"
     typical "^2.6.0"
 
-text-table@^0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -5304,7 +6058,7 @@ through2-filter@^2.0.0:
     through2 "~2.0.0"
     xtend "~4.0.0"
 
-through2@^0.6.0:
+through2@^0.6.0, through2@^0.6.1, through2@^0.6.3, through2@~0.6.1:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
   dependencies:
@@ -5318,7 +6072,7 @@ through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@2, through@^2.3.6, through@~2.3, through@~2.3.1:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -5367,6 +6121,10 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+tryit@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -5450,6 +6208,10 @@ underscore@^1.8.3:
 underscore@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
+
+uniq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
 
 unique-stream@^2.0.2:
   version "2.2.1"
@@ -5776,6 +6538,16 @@ write-file-atomic@^1.1.2:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
+write-file-stdout@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/write-file-stdout/-/write-file-stdout-0.0.2.tgz#c252d7c7c5b1b402897630e3453c7bfe690d9ca1"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
+
 ws@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.2.tgz#8a244fa052401e08c9886cf44a85189e1fd4067f"
@@ -5824,7 +6596,11 @@ yallist@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs@~3.10.0:
+yargs@^1.2.6:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-1.3.3.tgz#054de8b61f22eefdb7207059eaef9d6b83fb931a"
+
+yargs@^3.5.4, yargs@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
   dependencies:


### PR DESCRIPTION
Added linting steps with a Travis CI step.
This is set up with eslint and stylelint.

The tooling is a little different because the JS and CSS is inline and using later features which tripped up our other tools. There is also the benefit of using a Google backed eslint rules for Polymer.

## QA

```
./run test
```

When reviewing local site or demo, the site should look and act the same.