### PR TITLE
Add a "title" attribute to the card <a> tag

### DIFF
--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -94,7 +94,7 @@
     </style>
 
     <paper-card class="horizontal layout">
-      <a href="/tutorial/[[url]][[generateBackParameter]]">
+      <a href="/tutorial/[[url]][[generateBackParameter]]" title="[[heading]]">
         <div class="header horizontal">
           <div class="horizontal end-justified layout">
             <div class="light card-category">[[firstcategory]]</div>


### PR DESCRIPTION
I think the lack of title attribute on the card `<a>` tag is causing Google to generate confusing results titles:

![screenshot from 2017-06-30 17-41-37](https://user-images.githubusercontent.com/18480003/27743176-6e0fed2e-5dbb-11e7-880a-1952793d92a5.png)

This commit hopefully fixes it.