### PR TITLE
Override for images being forced at 100% width

### DIFF
--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -58,6 +58,10 @@
         background: rgba(25, 182, 238, 0.1);
         border-radius: 2px;
       }
+      #contentContainer google-codelab p img {
+        /* Override images being forced at 100% width */
+        width: auto;
+      }
     </style>
 
     <app-route


### PR DESCRIPTION
* Overrides the upstream base img styling https://github.com/googlecodelabs/codelab-components/blob/0b8dcb6458290d02e6ff9cdc0430d9c03973bbf3/step-style.html#L188
* Avoids blurriness and allows for smaller images in content.