### PR TITLE
Add feedback-link metadata to guidelines

### DIFF
--- a/examples/guidelines-snap-tutorials.md
+++ b/examples/guidelines-snap-tutorials.md
@@ -5,6 +5,7 @@ categories: snapcraft
 tags: tutorial,guidelines,snap
 difficulty: 2
 status: Published
+feedback-link: https://github.com/canonical-websites/tutorials.ubuntu.com/issues
 author: Javier Lopez <javier.lopez@example.com>
 published: 2017-01-13
 
@@ -51,6 +52,7 @@ categories: snapcraft
 tags: tutorial,guidelines,snap
 difficulty: 2
 status: Published
+feedback-link: https://github.com/canonical-websites/tutorials.ubuntu.com/issues
 author: Javier Lopez <javier.lopez@example.com>
 published: 2017-01-13
 


### PR DESCRIPTION
As we have started using `feedback-link` on production, we might as well add it to the guidelines.