### PR TITLE
New 404 page

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -3,7 +3,8 @@
   "shell": "src/ubuntu-tutorials-app.html",
   "fragments": [
     "src/codelabs-index.html",
-    "src/codelabs-page.html"
+    "src/codelabs-page.html",
+    "src/error-404.html"
   ],
   "sources": [
     "api/**/*",

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -85,7 +85,8 @@
       url="[[url]]/index.html"
       handle-as="text"
       loading="{{loading}}"
-      on-response="_loadTutorial">
+      on-response="_loadTutorial"
+      bubbles="true">
     </iron-ajax>
     <div id="contentContainer"></div>
   </template>

--- a/src/elements/tutorials-app-header.html
+++ b/src/elements/tutorials-app-header.html
@@ -65,7 +65,7 @@
       is: 'tutorials-app-header',
 
       properties: {
-        hidden: Boolean,
+        hidden: false,
       },
     });
   </script>

--- a/src/error-404.html
+++ b/src/error-404.html
@@ -1,0 +1,62 @@
+<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
+
+<dom-module id="error-404">
+  <template>
+    <style include="iron-flex iron-flex-alignment">
+      .content {
+        max-width: 1030px;
+        padding: 6.25rem 0;
+        width: 100%;
+      }
+
+      .description {
+        min-width: 375px;
+      }
+
+      h1 {
+        font-size: 2.8125em;
+        font-weight: 300;
+      }
+
+      p {
+        margin-top: 0;
+        font-size: 1.4375em;
+        font-weight: 300;
+      }
+    </style>
+
+    <div class="wrapper horizontal layout center-justified">
+      <div class="content horizontal layout wrap center-justified">
+        <div class="pictogram horizontal layout center-justified flex">
+          <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg?w=365" alt="Error owl" width="365">
+        </div>
+        <div class="description horizontal layout center-justified flex">
+          <div class="description vertical layout center-justified">
+            <h1>404: Page not found</h1>
+            <p>Sorry, we couldn’t find that page.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'error-404',
+
+      properties: {
+        requestedPage: {
+          type: String,
+        },
+      },
+
+      attached: function() {
+        this.fire('app-metadata', {
+          title: '404: Page not found | Ubuntu tutorials',
+          description: 'Sorry, we couldn\'t find that page.',
+        });
+      },
+    });
+  </script>
+</dom-module>

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -58,7 +58,7 @@
     <tutorials-app-header hidden="[[_isMainHeaderHidden(page)]]">
     </tutorials-app-header>
 
-    <iron-pages role="main" selected="[[page]]" attr-for-selected="name" fallback-selection="404">
+    <iron-pages role="main" selected="[[page]]" attr-for-selected="name">
       <section name="index">
         <codelabs-index id="page-index" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-index>
       </section>

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -8,6 +8,8 @@
 <link rel="import" href="elements/tutorials-app-header.html">
 <link rel="import" href="elements/websocket-reloader.html">
 
+<link rel="import" href="error-404.html">
+
 <dom-module id="ubuntu-tutorials-app">
   <link rel="lazy-import" group="codelabs-index" href="codelabs-index.html">
   <link rel="lazy-import" group="codelabs-page" href="codelabs-page.html">
@@ -56,12 +58,15 @@
     <tutorials-app-header hidden="[[_isMainHeaderHidden(page)]]">
     </tutorials-app-header>
 
-    <iron-pages role="main" selected="[[page]]" attr-for-selected="name">
+    <iron-pages role="main" selected="[[page]]" attr-for-selected="name" fallback-selection="404">
       <section name="index">
         <codelabs-index id="page-index" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-index>
       </section>
       <section name="tutorial">
         <codelabs-page id="page-tutorial" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-page>
+      </section>
+      <section name="404">
+        <error-404 requested-page="[[page]]"></error-404>
       </section>
     </iron-pages>
 
@@ -80,6 +85,7 @@
         isLoading: Boolean,
         page: {
           type: String,
+          value: 'index',
           reflectToAttribute: true,
         },
         routeData: Object,
@@ -116,6 +122,13 @@
           hrefToImport,
           function loadPage() {
             this.page = page;
+          },
+          function errorPage(event) {
+            let httpCode = event.target.__error.status;
+            switch(httpCode) {
+              case 404:
+                this.page = '404';
+            }
           }
         );
       },

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -102,9 +102,8 @@
 
       ready: function() {
         let el = document.querySelector('ubuntu-tutorials-app');
-        el.addEventListener('iron-ajax-error', function(request) {
-          let httpCode = request.detail.request.status;
-          this._loadErrorPage(httpCode);
+        el.addEventListener('iron-ajax-error', function(error) {
+          this._loadErrorPage();
         });
       },
 
@@ -131,18 +130,14 @@
           function loadPage() {
             this.page = page;
           },
-          function errorPage(event) {
-            let httpCode = event.target.__error.status;
-            this._loadErrorPage(httpCode);
+          function onImportError(event) {
+            this._loadErrorPage();
           }
         );
       },
 
-      _loadErrorPage: function _loadErrorPage(errorCode) {
-        switch(errorCode) {
-          case 404:
-            this.page = '404';
-        }
+      _loadErrorPage: function _loadErrorPage() {
+        this.page = '404';
       },
 
       _isMainHeaderHidden: function(page) {

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -125,12 +125,16 @@
           },
           function errorPage(event) {
             let httpCode = event.target.__error.status;
-            switch(httpCode) {
-              case 404:
-                this.page = '404';
-            }
+            this._loadErrorPage(httpCode);
           }
         );
+      },
+
+    _loadErrorPage: function _loadErrorPage(errorCode) {
+        switch(errorCode) {
+          case 404:
+            this.page = '404';
+        }
       },
 
       _isMainHeaderHidden: function(page) {
@@ -159,6 +163,13 @@
       },
 
     });
+
+    let el = document.querySelector('ubuntu-tutorials-app');
+    el.addEventListener('iron-ajax-error', function(request) {
+      let httpCode = request.detail.request.status;
+      this._loadErrorPage(httpCode);
+    });
+
   </script>
 
 </dom-module>

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -130,7 +130,7 @@
         );
       },
 
-    _loadErrorPage: function _loadErrorPage(errorCode) {
+      _loadErrorPage: function _loadErrorPage(errorCode) {
         switch(errorCode) {
           case 404:
             this.page = '404';

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -100,6 +100,14 @@
         Polymer.AppMetadata.requestAvailability();
       },
 
+      ready: function() {
+        let el = document.querySelector('ubuntu-tutorials-app');
+        el.addEventListener('iron-ajax-error', function(request) {
+          let httpCode = request.detail.request.status;
+          this._loadErrorPage(httpCode);
+        });
+      },
+
       _loadPage: function _loadPage(page) {
         // load page import on demand.
         page = page || 'index';
@@ -163,13 +171,6 @@
       },
 
     });
-
-    let el = document.querySelector('ubuntu-tutorials-app');
-    el.addEventListener('iron-ajax-error', function(request) {
-      let httpCode = request.detail.request.status;
-      this._loadErrorPage(httpCode);
-    });
-
   </script>
 
 </dom-module>


### PR DESCRIPTION
This adds a 404 page following the style of www.ubuntu.com.

This is initial work towards #200 but this is not complete and we will want to have a bigger project to improve this in the near future.

## QA
I have a feeling the demo service won't allow you to see it easily.

I am testing by running `polymer serve` directly and visiting a fake URL, without the run command.

## Screenshots

![selection_005](https://user-images.githubusercontent.com/322693/30439374-779cf134-996b-11e7-92e1-5ec35a39f2de.png)

![selection_006](https://user-images.githubusercontent.com/322693/30439373-77978e9c-996b-11e7-93ca-dca2e0018f81.png)
