### PR TITLE
Fixed tutorial sorting errors on chrome

### DIFF
--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -358,27 +358,27 @@
         switch(sortOption) {
           case 'published-asc':
             return function(a, b) {
-              return a.published > b.published;
+              return (a.published > b.published ? 1 : -1);
             };
           case 'published-desc':
             return function(a, b) {
-              return a.published < b.published;
+              return (a.published < b.published ? 1 : -1);
             };
           case 'duration-asc':
             return function(a, b) {
-              return a.duration > b.duration;
+              return (a.duration > b.duration ? 1 : -1);
             };
           case 'duration-desc':
             return function(a, b) {
-              return a.duration < b.duration;
+              return (a.duration < b.duration ? 1 : -1);
             };
           case 'difficulty-desc':
             return function(a, b) {
-              return a.difficulty < b.difficulty;
+              return (a.difficulty < b.difficulty ? 1 : -1);
             };
           case 'difficulty-asc':
             return function(a, b) {
-              return a.difficulty > b.difficulty;
+              return (a.difficulty > b.difficulty ? 1 : -1);
             };
         };
       },


### PR DESCRIPTION
## Done
- Fixed sorting errors on chromium-based browsers (date, duration and difficulty)
- Changed _getSortFunction to return integers (-1, 1) instead of truthiness

## QA
- Check out this feature branch
- Run the site using the command `./run serve tutorials`
- View the site locally in your web browser at: [http://localhost:8016]
- Check that the sorting works as intended on Chrome and Firefox

## Issue / Card
Fixes #304 
