### PR TITLE
Fixed back button on tutorial page

### DIFF
--- a/src/elements/tutorials-app-header.html
+++ b/src/elements/tutorials-app-header.html
@@ -51,7 +51,7 @@
           <app-toolbar>
             <div class="app-logo">
               <a href="/">
-                  <tutorials-app-logo></tutorials-app-logo>
+                <tutorials-app-logo></tutorials-app-logo>
               </a>
             </div>
           </app-toolbar>

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -55,9 +55,6 @@
 
     <websocket-reloader></websocket-reloader>
 
-    <tutorials-app-header hidden="[[_isMainHeaderHidden(page)]]">
-    </tutorials-app-header>
-
     <iron-pages role="main" selected="[[page]]" attr-for-selected="name">
       <section name="index">
         <codelabs-index id="page-index" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-index>
@@ -69,6 +66,9 @@
         <error-404 requested-page="[[page]]"></error-404>
       </section>
     </iron-pages>
+
+    <tutorials-app-header hidden="[[_isMainHeaderHidden(page)]]">
+    </tutorials-app-header>
 
   </template>
 

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -55,8 +55,11 @@
 
     <websocket-reloader></websocket-reloader>
 
+
+
     <iron-pages role="main" selected="[[page]]" attr-for-selected="name">
       <section name="index">
+        <tutorials-app-header hidden="[[_isMainHeaderHidden(page)]]"></tutorials-app-header>
         <codelabs-index id="page-index" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-index>
       </section>
       <section name="tutorial">
@@ -66,9 +69,6 @@
         <error-404 requested-page="[[page]]"></error-404>
       </section>
     </iron-pages>
-
-    <tutorials-app-header hidden="[[_isMainHeaderHidden(page)]]">
-    </tutorials-app-header>
 
   </template>
 


### PR DESCRIPTION
## Done
- Fixed back button on tutorial pages
- Reordered location of tutorial-header in main app page (was a problem in lifecycle - hidden function was firing before relevant attributes loaded in)

## QA
- Check out this feature branch
- Run the site using the command `./run serve tutorials`
- View the site locally in your web browser at: [http://localhost:8016]
- Check that the back button works as intended on any tutorial page

## Issue / Card
Fixes #173