### PR TITLE
Append #0 in links to avoid extra browser history

### DIFF
--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -116,7 +116,7 @@
 
     <paper-card>
       <div class="card-content">
-        <a href="/tutorial/[[url]][[generateBackParameter]]" title="[[heading]]">
+        <a href="/tutorial/[[url]][[generateBackParameter]]#0" title="[[heading]]">
           <div class="header vertical layout">
             <div class="horizontal end-justified layout">
               <div class="light card-category">[[firstcategory]]</div>


### PR DESCRIPTION
If no # number is present while loading a tutorial, Codelabs will add it
to the current location and creates an extra item in the history. This
means you have to click back twice to return out of a tutorial.

This avoids this step.


## QA
In the demo, click a tutorial and then hit back. It should only take one step to return to the home page.