### PR TITLE
Added functionality to header back button to return to referrer

### DIFF
--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -126,7 +126,8 @@
       ],
 
       ready: function() {
-        if (document.referrer && document.referrer.indexOf(window.location.hostname) === -1) {
+        if (document.referrer &&
+            document.referrer.indexOf(window.location.hostname) === -1) {
           this.backURL = document.referrer;
         }
         this.async(function() {

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -126,10 +126,14 @@
       ],
 
       ready: function() {
+        // If client linked here AND referral wasn't within host, change backURL
         if (document.referrer &&
             document.referrer.indexOf(window.location.hostname) === -1) {
           this.backURL = document.referrer;
         }
+
+        // Change component's original goToHome function to custom one
+        // Async function allows querying of dynamic DOM content
         this.async(function() {
           this.$$('#codelabobj')._goToHome = this._goToHome.bind(this);
         }.bind(this), 50);

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -114,6 +114,10 @@
           type: Array,
           notify: true,
         },
+        backURL: {
+          type: String,
+          value: '/',
+        },
       },
 
       observers: [
@@ -121,10 +125,23 @@
         '_onPageChange(routeData.codelab)',
       ],
 
+      ready: function() {
+        if (document.referrer && document.referrer.indexOf(window.location.hostname) === -1) {
+          this.backURL = document.referrer;
+        }
+        this.async(function() {
+          this.$$('#codelabobj')._goToHome = this._goToHome.bind(this);
+        }.bind(this), 50);
+      },
+
       _onPageChange: function(slug) {
         if (slug) {
           this.$.tutorialAjax.generateRequest();
         }
+      },
+
+      _goToHome: function() {
+        window.location.href = this.backURL;
       },
 
       _handleLoading: function(loading) {
@@ -175,6 +192,7 @@
       _codelaburl: function(codelabpath) {
         return '/src/codelabs/' + codelabpath;
       },
+
     });
   </script>
 </dom-module>


### PR DESCRIPTION
## Done
- Added backURL property to codelabs-page that stores the referrer URL if it exists
- Changed default google-codelab goToHome function to custom one that redirects to backURL

## QA
- Check out this feature branch
- Run the site using the command `./run serve tutorials`
- View the site locally in your web browser at: [http://localhost:8016]
- Check that the header back button redirects to referrer if linked to from another site
- Otherwise it should redirect to index
- **NOTE** document.referrer is null when directed from HTTPS to HTTP, so it will only work on the demo server and http://localhost when the referrer is also an HTTP site (see [here](https://www.e-nor.com/blog/google-analytics/https-to-http-secure-to-nonsecure-referrer-loss))

## Issue / Card
Fixes #356 