### PR TITLE
Fixed padding on no results search message

### DIFF
--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -164,6 +164,10 @@
         font-weight: normal;
       }
 
+      .no-results {
+        padding-left: 10px;
+      }
+
       .no-results h2 {
         margin-bottom: 1em;
       }


### PR DESCRIPTION
## Done

- Added 10px padding-left to no results search message so it aligns with the rest of the page


## QA

- Check that the no results search message lines up with the rest of the page


## Issue / Card

Fixes #162 