### PR TITLE
Made cards responsive for tablet-size displays

### DIFF
--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -174,17 +174,18 @@
 
       codelabs-card {
         margin: 10px;
+        width: 100%;
       }
 
-      @media only screen and (max-width: 769px) {
+      @media only screen and (min-width: 625px) {
         codelabs-card {
-          width: 100%;
+          width: calc(50% - 20px);
         }
       }
 
-      @media only screen and (min-width: 769px) {
+      @media only screen and (min-width: 901px) {
         codelabs-card {
-          width: 306px;
+          width: calc(33.3% - 20px);
         }
       }
 

--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -23,8 +23,10 @@
         font-family: 'Ubuntu', Helvetica, Arial;
         height: 100%;
         position: relative;
+        width: 100%;
 
         --paper-card-content: {
+          height: 100%;
           padding: 0;
         };
       }
@@ -32,6 +34,9 @@
       paper-card a {
         color: var(--primary-text-color);
         overflow: hidden;
+        display: flex;
+        height: 100%;
+        flex-direction: column;
       }
 
       .header {
@@ -41,6 +46,7 @@
         min-height: 120px;
         color: #fff;
         border-radius: 2px 2px 0 0;
+        flex: 1;
       }
 
       .body {
@@ -68,8 +74,8 @@
       }
 
       .duration {
-        text-align: right;
-        width: 100%;
+        min-width: 109px;
+        align-self: flex-end;
       }
 
       .card-actions {
@@ -84,14 +90,14 @@
       }
 
       .summary {
-        height: 170px;
+        min-height: 200px;
         margin: 0;
       }
 
       .meta {
         color: var(--secondary-text-color);
         font-size: 0.875em;
-        white-space: nowrap;
+        flex-wrap: wrap;
       }
 
       .meta--tags {
@@ -112,6 +118,11 @@
       .duration__value {
         color: var(--primary-text-color);
       }
+
+      .layout.start-justified {
+        justify-content: space-between;
+      }
+
     </style>
 
     <paper-card>

--- a/src/elements/tutorials-filters.html
+++ b/src/elements/tutorials-filters.html
@@ -13,7 +13,7 @@
       .filter-label {
         display: inline-block;
         float: left;
-        margin: 10px 0.625rem 0.5rem 2px;
+        margin: 10px 0.625rem 0.5rem 0;
         position: relative;
         width: auto;
       }
@@ -84,10 +84,6 @@
         }
       }
 
-      .filter paper-dropdown-menu {
-        margin-right: 2px;
-      }
-
       .sort {
         display: flex;
         flex-direction: column;
@@ -103,10 +99,6 @@
           margin: 1em 0 1em 1em;
           width: auto;
         }
-      }
-
-      .sort paper-dropdown-menu {
-        margin-right: 2px;
       }
 
       paper-button.button--primary {


### PR DESCRIPTION
## Done

- Made tutorial cards responsive for tablet-size displays
- General alignment and responsiveness fixes (search and filter bars now aligned with borders, difficulty/duration strip now stacks when card thins)

## QA

- Check that the tutorial cards are responsive at all screen sizes. 3 cards per row for large screens (901px+), 2 for medium screens (625px - 900px), 1 for small screens (624px-)


## Issue / Card
Fixes #164 