### PR TITLE
Fixed search bar styling on mobile Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     body {
       margin: 0;
       font-family: 'Ubuntu', sans-serif;
-      font-weight: 300;
+      font-weight: normal;
       line-height: 1.5;
       min-height: 100vh;
       background: #f7f7f7 url('https://assets.ubuntu.com/v1/f8a323a7-image-background-paper.png') center top repeat-y;

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -27,6 +27,7 @@
       input[type='search'] {
         background-color: white;
         border: 1px solid var(--color-mid-light);
+        border-radius: 0;
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12) inset;
         box-sizing: border-box;
         font-family: 'Ubuntu', Helvetica, Arial;

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -119,7 +119,6 @@
       }
 
       .intro p {
-        font-weight: 300;
         max-width: 620px;
       }
 

--- a/src/elements/tutorials-filters.html
+++ b/src/elements/tutorials-filters.html
@@ -27,7 +27,6 @@
 
       paper-dropdown-menu {
         font-family: 'Ubuntu', Helvetica, Arial;
-        width: 100%;
 
         --paper-input-container-focus-color: white;
 
@@ -63,10 +62,6 @@
         paper-dropdown-menu {
           width: 228px;
         }
-      }
-
-      paper-menu-button {
-        width: 100%;
       }
 
       .filter {
@@ -121,23 +116,42 @@
         padding: 0;
       }
 
-      paper-item {
-        font-weight: 300;
-        width: 204px;
-        cursor: pointer;
+      @media only screen and (min-width: 769px) {
+        paper-listbox {
+          width: inherit;
+        }
       }
 
-      paper-item.iron-selected {
-        font-weight: 300;
+      paper-item {
+        font-family: 'Ubuntu', Helvetica, Arial;
+        padding-left: 10px;
+        cursor: pointer;
+        box-sizing: border-box;
       }
+
+      .custom-width {
+        width: calc(100vw - 55px);
+        
+        --paper-dropdown-menu-button {
+          width: 100%;
+          left: 0;
+        }
+      }
+
+      @media only screen and (min-width: 769px) {
+        .custom-width {
+          width: 228px;
+        }
+      }
+
     </style>
 
     <div class="horizontal clearfix end">
       <div class="filters-wrapper">
         <div class="filter">
           <p class="filter-label">Filter results by:</p>
-          <paper-dropdown-menu label="<topic>" no-label-float noink no-animations>
-            <paper-listbox id="categorySelect" class="dropdown-content" attr-for-selected="data-sort" selected="{{selectedCategory}}">
+          <paper-dropdown-menu class="custom-width" label="<topic>" no-label-float noink no-animations>
+            <paper-listbox id="categorySelect" class="custom-width dropdown-content" attr-for-selected="data-sort" selected="{{selectedCategory}}">
               <template is="dom-repeat" items="[[_toArray(categoryOptions)]]">
                 <paper-item data-sort$="[[item.value]]">[[item.name]]</paper-item>
               </template>
@@ -147,8 +161,8 @@
 
         <div class="sort">
           <p class="filter-label">Sort results by:</p>
-          <paper-dropdown-menu no-label no-label-float noink no-animations>
-            <paper-listbox id="sortSelect" class="dropdown-content" attr-for-selected="data-sort" selected="{{selectedSort}}">
+          <paper-dropdown-menu class="custom-width" no-label no-label-float noink no-animations>
+            <paper-listbox id="sortSelect" class="custom-width dropdown-content" attr-for-selected="data-sort" selected="{{selectedSort}}">
               <template is="dom-repeat" items="[[_toArray(sortOptions)]]">
                 <paper-item data-sort$="[[item.value]]">[[item.name]]</paper-item>
               </template>


### PR DESCRIPTION
## Done

- Fixed search bar styling on mobile Safari by removing border-radius
- Search bars were given webkit-appearance of none in an earlier commit


## QA

- Check that styling of search bar is the same as the filter dropdowns on small screen Safari browser


## Issue / Card

Fixes #156 