### PR TITLE
Fixed search bar styling on mobile Safari

### DIFF
--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -27,6 +27,7 @@
       input[type='search'] {
         background-color: white;
         border: 1px solid var(--color-mid-light);
+        border-radius: 0;
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12) inset;
         box-sizing: border-box;
         font-family: 'Ubuntu', Helvetica, Arial;


### PR DESCRIPTION
## Done

- Fixed search bar styling on mobile Safari by removing border-radius
- Search bars were given webkit-appearance of none in an earlier commit


## QA

- Check that styling of search bar is the same as the filter dropdowns on small screen Safari browser


## Issue / Card

Fixes #156 