### PR TITLE
Set default port on prpl-server to 80

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "polymer-build": "npm-run-all 'polymer build {@}' --",
     "polymer-lint": "npm-run-all 'polymer lint {@}' --",
     "polymer-serve": "npm-run-all 'polymer serve {@}' --",
-    "prpl-server": "prpl-server --root build/ --host 0.0.0.0",
+    "prpl-server": "prpl-server --root build/ --host 0.0.0.0 --port 80",
     "serve": "npm-run-all 'serve-examples {@}' --",
     "serve-examples": "./bin/serve $(if [ -z \"$*\" ]; then echo \"examples\"; fi)",
     "serve-live": "./bin/serve",


### PR DESCRIPTION
Set prpl-server to serve on port 80 as default.

## QA

- `yarn install`
- `bower install`
- `yarn run build-all`
- `yarn run prpl-server`
- Site should be accessible on http://localhost:80