### PR TITLE
Force full width styling on header on first load.

### DIFF
--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -225,67 +225,69 @@
       pattern="/:event"
       data="{{routeData}}"></app-route>
 
-    <tutorials-app-header></tutorials-app-header>
-    <div>
-      <template is="dom-if" if="{{currentEvent.id}}">
-        <header class="horizontal layout event-wrapper">
-          <img class="event-logo" src="/images/events/{{currentEvent.logo}}" />
-          <div class="event-description">
-            <h1>{{currentEvent.name}}</h1>
-            <p>{{currentEvent.description}}</p>
-          </div>
-        </div>
-      </template>
-      <div class="content">
-        <div class="wrap intro">
-          <h1>Let's get coding!</h1>
-          <p>Ubuntu Tutorials are just like learning from pair programming except you can do it on your own. They provide a step-by-step process to doing development and devops activities on Ubuntu machines, servers or devices.</p>
-
-          <p>For now, the tutorials focus mainly on building and using snaps and Ubuntu Core.<br /><a href="https://github.com/ubuntudesign/tutorials.ubuntu.com/issues/new" class="external">If you'd like to see tutorials cover more topics, let us know</a></p>
-
-          <div>
-            <label class="accessibility-aid" for="edit-keys" hidden="hidden">Search</label>
-            <input id="edit-keys" type="search" placeholder="Search tutorials" is="iron-input" bind-value="{{filterSearch}}" />
-            <paper-icon-button class="search" icon="search"></paper-icon-button>
-            <template is="dom-if" if="[[filterSearch]]">
-              <h2 class="heading-results">
-                <span class="heading-results__highlight">[[searchResultCount]]</span> search results for <span class="heading-results__highlight">[[filterSearch]]</span>
-              </h2>
-            </template>
-          </div>
-          <div>
-            <tutorials-filters
-              selected-category="{{filterCategory}}"
-              selected-sort="{{filterSort}}"
-              selected-user="{{filterUser}}"
-              >
-            </tutorials-filters>
-          </div>
-        </div>
-
-        <div class="horizontal layout end">
-          <div class="flex"></div>
-        </div>
-        <div class="horizontal layout wrap">
-          <template is="dom-if" if="[[!isEmpty]]">
-            <template is="dom-repeat" items="[[filteredTutorials]]" sort="[[_getSortFunction(filterSort)]]">
-              <codelabs-card heading="[[item.title]]" summary="[[item.summary]]" category="[[item.category]]"
-                            difficulty="[[item.difficulty]]" duration="[[item.duration}}" tags="[[item.tags]]"
-                            published="[[item.published]]" url="[[item.url]]" currenturl="[[route.prefix]][[route.path]]"
-                            ></codelabs-card>
-            </template>
-          </template>
-          <template is="dom-if" if="[[isEmpty]]">
-            <div class="no-results">
-              <h2>Why not try widening your search?</h2>
-              <h3>You can do this by:</h3>
-              <ul>
-                <li>Removing any filters</li>
-                <li>Using individual words instead of phrases</li>
-                <li>Trying a different spelling</li>
-              </ul>
+    <div class="layout vertical">
+      <tutorials-app-header></tutorials-app-header>
+      <div>
+        <template is="dom-if" if="{{currentEvent.id}}">
+          <header class="horizontal layout event-wrapper">
+            <img class="event-logo" src="/images/events/{{currentEvent.logo}}" />
+            <div class="event-description">
+              <h1>{{currentEvent.name}}</h1>
+              <p>{{currentEvent.description}}</p>
             </div>
-          </template>
+          </div>
+        </template>
+        <div class="content">
+          <div class="wrap intro">
+            <h1>Let's get coding!</h1>
+            <p>Ubuntu Tutorials are just like learning from pair programming except you can do it on your own. They provide a step-by-step process to doing development and devops activities on Ubuntu machines, servers or devices.</p>
+
+            <p>For now, the tutorials focus mainly on building and using snaps and Ubuntu Core.<br /><a href="https://github.com/ubuntudesign/tutorials.ubuntu.com/issues/new" class="external">If you'd like to see tutorials cover more topics, let us know</a></p>
+
+            <div>
+              <label class="accessibility-aid" for="edit-keys" hidden="hidden">Search</label>
+              <input id="edit-keys" type="search" placeholder="Search tutorials" is="iron-input" bind-value="{{filterSearch}}" />
+              <paper-icon-button class="search" icon="search"></paper-icon-button>
+              <template is="dom-if" if="[[filterSearch]]">
+                <h2 class="heading-results">
+                  <span class="heading-results__highlight">[[searchResultCount]]</span> search results for <span class="heading-results__highlight">[[filterSearch]]</span>
+                </h2>
+              </template>
+            </div>
+            <div>
+              <tutorials-filters
+                selected-category="{{filterCategory}}"
+                selected-sort="{{filterSort}}"
+                selected-user="{{filterUser}}"
+                >
+              </tutorials-filters>
+            </div>
+          </div>
+
+          <div class="horizontal layout end">
+            <div class="flex"></div>
+          </div>
+          <div class="horizontal layout wrap">
+            <template is="dom-if" if="[[!isEmpty]]">
+              <template is="dom-repeat" items="[[filteredTutorials]]" sort="[[_getSortFunction(filterSort)]]">
+                <codelabs-card heading="[[item.title]]" summary="[[item.summary]]" category="[[item.category]]"
+                              difficulty="[[item.difficulty]]" duration="[[item.duration}}" tags="[[item.tags]]"
+                              published="[[item.published]]" url="[[item.url]]" currenturl="[[route.prefix]][[route.path]]"
+                              ></codelabs-card>
+              </template>
+            </template>
+            <template is="dom-if" if="[[isEmpty]]">
+              <div class="no-results">
+                <h2>Why not try widening your search?</h2>
+                <h3>You can do this by:</h3>
+                <ul>
+                  <li>Removing any filters</li>
+                  <li>Using individual words instead of phrases</li>
+                  <li>Trying a different spelling</li>
+                </ul>
+              </div>
+            </template>
+          </div>
         </div>
       </div>
     </div>

--- a/src/elements/tutorials-app-header.html
+++ b/src/elements/tutorials-app-header.html
@@ -8,21 +8,35 @@
 <dom-module id="tutorials-app-header">
   <template>
     <style>
+      :host {
+        @apply --header-size;
+
+        --header-size: {
+          height: 48px;
+          width: 100%;
+        }
+      }
+
       app-header {
         background-color: var(--app-primary-color);
         color: white;
         padding: 0;
+
+        @apply --header-size;
       }
 
       app-header-layout {
         z-index: 9999;
+
+        @apply --header-size;
       }
 
       app-toolbar {
         margin: 0 auto;
         max-width: 984px;
         padding: 0;
-        height: 48px;
+
+        @apply --header-size;
       }
 
       .app-logo {
@@ -45,7 +59,7 @@
         --paper-input-container-input-color: white;
       }
     </style>
-    <app-header-layout>
+    <app-header-layout fullbleed>
         <app-header fixed>
           <app-toolbar>
             <div class="app-logo">

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../bower_components/app-route/app-location.html">
 <link rel="import" href="../bower_components/app-route/app-route.html">
 <link rel="import" href="../bower_components/iron-ajax/iron-ajax.html">
+<link rel="import" href="../bower_components/iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="../bower_components/iron-pages/iron-pages.html">
 
 <link rel="import" href="elements/websocket-reloader.html">
@@ -14,7 +15,7 @@
   <link rel="lazy-import" group="error-404" href="error-404.html">
 
   <template>
-    <style>
+    <style include="iron-flex">
       :root {
         --ubuntu-orange: #e95420;
         --primary-color: var(--ubuntu-orange);
@@ -54,11 +55,13 @@
 
     <websocket-reloader></websocket-reloader>
 
-    <iron-pages id="pages" role="main" selected="[[page]]" attr-for-selected="name">
-      <codelabs-index name="index" id="page-index" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-index>
-      <codelabs-page name="tutorial" id="page-tutorial" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-page>
-      <error-404 name="404" requested-page="[[page]]"></error-404>
-    </iron-pages>
+    <div class="layout vertical">
+      <iron-pages id="pages" role="main" selected="[[page]]" attr-for-selected="name">
+        <codelabs-index name="index" id="page-index" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-index>
+        <codelabs-page name="tutorial" id="page-tutorial" route="[[subroute]]" codelabs="{{codelabs}}"></codelabs-page>
+        <error-404 name="404" requested-page="[[page]]"></error-404>
+      </iron-pages>
+    </div>
 
   </template>
 


### PR DESCRIPTION
Stop Chrome creating the header with no size so that it looks unstyled (until you resize the browser).

- Update the header styling to force a size across nested elements.
- Also set the main app file and tutorials list pages to use iron layout classes.

## QA
Check output in multiple browsers and check the header looks correct on first load.