### PR TITLE
Remove es6-unbundled build and limit dev-reloader

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -38,17 +38,6 @@
     "insertPrefetchLinks": true,
     "basePath":true,
     "browserCapabilities": ["es2015"]
-  },{
-    "name": "es6-unbundled",
-    "bundle": false,
-    "js": {"minify": true, "compile": false},
-    "css": {"minify": true},
-    "html": {"minify": true},
-    "addServiceWorker": true,
-    "addPushManifest": true,
-    "insertPrefetchLinks": true,
-    "basePath":true,
-    "browserCapabilities": ["es2015", "push"]
   }],
   "lint": {
     "rules": ["polymer-2-hybrid"]

--- a/src/elements/websocket-reloader.html
+++ b/src/elements/websocket-reloader.html
@@ -13,7 +13,11 @@
       },
 
       ready: function() {
-        this._reconnect();
+        let isLocal = ['localhost', '127.0.0.1'].indexOf(location.hostname);
+        let isHTTPS = location.protocol === 'https:';
+        if (isLocal && !isHTTPS) {
+          this._reconnect();
+        }
       },
 
       // connect websocket and different handlers


### PR DESCRIPTION
The es6-unbundled build is generating 404 errors on our Kubernetes deployment, when accessed with Chrome. This disables the build falling back to es6-bundled.

This disabled the build that is causing us problems and I will create an issue to investigate and correct the problem.

This also limits the websocket-reloader to only running on non HTTPS localhost, preventing a secure error on deployment.


## QA
`./run exec yarn run build-all` and check the builds happen correctly.

An image for this is currently on Docker hub and can be checked by reviewing https://github.com/canonical-webteam/deployment-configs/pull/17

## New Issues
Issue created to investigate and revert work: https://github.com/canonical-websites/tutorials.ubuntu.com/issues/410