### PR TITLE
Correct tutorial page styling

### DIFF
--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -12,6 +12,12 @@
         --google-codelab-header-background: var(--secondary-color);
         --paper-blue-500: var(--secondary-color);
         --google-codelab-fab-background: var(--secondary-color);
+
+        --paper-toolbar-title: {
+          font-family: 'Ubuntu', sans-serif;
+          font-size: 1.17em;
+          font-weight: var(--font-weight);
+        };
       }
 
       :host {

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -25,6 +25,12 @@
         min-height: 100vh;
       }
 
+      google-codelab {
+        --paper-drawer-panel-main-container: {
+          background: transparent;
+        };
+      }
+
       google-codelab-step {
         --google-codelab-step-code: {
           font-family: 'Ubuntu Mono', Helvetica, Arial;

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -28,6 +28,7 @@
         --color-light: #f7f7f7;
         --color-mid-light: #cdcdcd;
         --color-dark: #333;
+        --font-weight: 300;
       }
 
       :host {


### PR DESCRIPTION
Fix some styling regressions created on `/tutorial/*` pages:

- Set font family, size, and weight on header.
- Set tutorial wrapper to have a transparent background and not block primary background.

## QA

Compare a Tutorial on demo and live. The header should looks the same.

You should see the background image correctly.