### PR TITLE
Stop tooltips on Firefox by setting title on a child

### DIFF
--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -137,6 +137,10 @@
         let el = document.querySelector('ubuntu-tutorials-app');
         el.addEventListener('google-codelab-ready', function(error) {
           this._attachFeedbackForm();
+
+          // Set an empty title on the first child element of the codelab
+          // Firefox picks up Codelab's title attribute and makes a tooltip
+          contentContainer.querySelector('#drawer').setAttribute('title', '');
         }.bind(this));
       },
 


### PR DESCRIPTION
This is to fix #73.

The codelab element sets a `title=""` attribute. In Chrome, this is fine. In Firefox it creates a tooltip that pops up anywhere on the page when you stop moving your mouse.

I tried unsetting the title with Javascript but it also unsets the title text in the header bar.

This isn't my favourite method but that tooltip is quite annoying and I would really like to stop it.

## QA

- Check demo in Firefox, don't see a tooltip when you hover on a tutorial page!