### PR TITLE
Add electron-builder to package.json

### DIFF
--- a/tutorials/packaging/snap-a-website.md
+++ b/tutorials/packaging/snap-a-website.md
@@ -238,6 +238,9 @@ In your favorite editor, create a `package.json` file with the following content
   "scripts": {
     "start": "electron ."
   },
+  "devDependencies": {
+    "electron-builder": "^19.45.5"
+  },   
   "build": {
     "linux": {
       "target": ["dir"]


### PR DESCRIPTION
I'm not totally sure about the syntax for the version, so a review from somebody who knows JS would be nice.