### PR TITLE
Repoint "Create your first snap" links

### DIFF
--- a/tutorials/packaging/basic-snap-usage/basic-snap-usage.md
+++ b/tutorials/packaging/basic-snap-usage/basic-snap-usage.md
@@ -319,7 +319,7 @@ By now you should have found snaps in the store, installed and updated them, cha
 [snap-openwrt feed]: https://github.com/teknoraver/snap-openwrt/blob/master/README.md
 [http://localhost:9000/]: http://localhost:9000/
 [Advanced snap usage]: https://tutorials.ubuntu.com/tutorial/advanced-snap-usage
-[Creating your first snap]: https://tutorials.ubuntu.com/tutorial/create-first-snap
+[Creating your first snap]: https://tutorials.ubuntu.com/tutorial/create-your-first-snap
 [snapcraft forum]: https://forum.snapcraft.io/
 [Snapcraft.io documentation]: http://snapcraft.io/docs/
 [contact us and the broader community]: http://snapcraft.io/community/

--- a/tutorials/packaging/snap-a-nodejs-app.md
+++ b/tutorials/packaging/snap-a-nodejs-app.md
@@ -649,7 +649,7 @@ As a bonus, you have as well some basic training on systemd common commands to s
 
 [chucknorris.io]: https://chucknorris.io
 [basic snap usage]: https://tutorials.ubuntu.com/tutorial/basic-snap-usage
-[create your first snap]: https://tutorials.ubuntu.com/tutorial/create-first-snap
+[create your first snap]: https://tutorials.ubuntu.com/tutorial/create-your-first-snap
 [here-3]: https://github.com/ubuntu/snap-tutorials-code/tree/master/build-a-nodejs-service/step3
 [here-4]: https://github.com/ubuntu/snap-tutorials-code/tree/master/build-a-nodejs-service/step4
 [this]: https://github.com/ubuntu/snap-tutorials-code/tree/master/build-a-nodejs-service/final

--- a/tutorials/packaging/snap-a-python-application.md
+++ b/tutorials/packaging/snap-a-python-application.md
@@ -648,7 +648,7 @@ You now know how to snap a simple Python application, the available options and 
 [httpstat]: https://github.com/reorx/httpstat
 [https://www.ubuntu.com]: https://www.ubuntu.com
 [basic snap usage]: https://tutorials.ubuntu.com/tutorial/basic-snap-usage
-[create your first snap]: https://tutorials.ubuntu.com/tutorial/create-first-snap
+[create your first snap]: https://tutorials.ubuntu.com/tutorial/create-your-first-snap
 [here]: https://github.com/ubuntu/snap-tutorials-code/tree/master/snap-python-app/step3
 [this]: https://github.com/ubuntu/snap-tutorials-code/tree/master/snap-python-app/final
 [snapcraft forum]: https://forum.snapcraft.io/


### PR DESCRIPTION
Fixes the broken link to "Create your first snap" on 3 tutorials.

Example: 
The second bullet point under "Next Steps" on this page has a broken link.
https://tutorials.ubuntu.com/tutorial/basic-snap-usage#5