### PR TITLE
Switch to Ubuntu Light

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   <style>
     body {
       margin: 0;
-      font-family: 'Ubuntu', sans-serif;
+      font-family: 'Ubuntu Light', sans-serif;
       font-weight: 300;
       line-height: 1.5;
       min-height: 100vh;

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -31,7 +31,7 @@
         border-radius: 0;
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12) inset;
         box-sizing: border-box;
-        font-family: 'Ubuntu', Helvetica, Arial;
+        font-family: 'Ubuntu Light', Helvetica, Arial;
         font-size: 1em;
         font-weight: 300;
         height: 44px;
@@ -107,7 +107,7 @@
         box-sizing: border-box;
         clear: both;
         display: block;
-        font-family: 'Ubuntu', Helvetica, Arial;
+        font-family: 'Ubuntu Light', Helvetica, Arial;
         height: 100%;
         overflow: hidden;
         padding: 0 10px 10px;

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -14,7 +14,7 @@
         --google-codelab-fab-background: var(--secondary-color);
 
         --paper-toolbar-title: {
-          font-family: 'Ubuntu', sans-serif;
+          font-family: 'Ubuntu Light', sans-serif;
           font-size: 1.17em;
           font-weight: var(--font-weight);
         };

--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -20,7 +20,7 @@
       }
 
       paper-card {
-        font-family: 'Ubuntu', Helvetica, Arial;
+        font-family: 'Ubuntu Light', Helvetica, Arial;
         height: 100%;
         position: relative;
         width: 100%;
@@ -55,7 +55,7 @@
 
       .heading {
         margin: 10px 0 0;
-        font-family: 'Ubuntu', Helvetica, Arial;
+        font-family: 'Ubuntu Light', Helvetica, Arial;
         font-size: 28px;
         font-weight: 300;
       }

--- a/src/elements/tutorial-feedback.html
+++ b/src/elements/tutorial-feedback.html
@@ -53,7 +53,7 @@
         background-color: #0e8420;
         color: #fff;
         text-transform: capitalize;
-        font-family: 'Ubuntu';
+        font-family: 'Ubuntu Light';
         padding-left: 24px;
         padding-right: 24px;
         height: 42px;
@@ -87,7 +87,7 @@
         width: 300px;
         margin-bottom: 0;
         margin-right: 15px;
-        font-family: 'Ubuntu';
+        font-family: 'Ubuntu Light';
         font-size: 1em;
       }
 

--- a/src/elements/tutorials-filters.html
+++ b/src/elements/tutorials-filters.html
@@ -26,7 +26,7 @@
       }
 
       paper-dropdown-menu {
-        font-family: 'Ubuntu', Helvetica, Arial;
+        font-family: 'Ubuntu Light', Helvetica, Arial;
 
         --paper-input-container-focus-color: white;
 
@@ -40,7 +40,7 @@
 
         --paper-input-container-input: {
           color: var(--primary-text-color);
-          font-family: 'Ubuntu', Helvetica, Arial;
+          font-family: 'Ubuntu Light', Helvetica, Arial;
           font-weight: 300;
           width: 100%;
           display: block;
@@ -128,7 +128,7 @@
       }
 
       paper-item {
-        font-family: 'Ubuntu', Helvetica, Arial;
+        font-family: 'Ubuntu Light', Helvetica, Arial;
         padding-left: 10px;
         cursor: pointer;
         box-sizing: border-box;


### PR DESCRIPTION
Since last week, all fonts on the site look bold on webkit browsers. This fixes it without any style regression on both Firefox and Chromium-based browsers (tested on Chrome/Chromium/Vivaldi).