### PR TITLE
Set prpl-server to proxy bots to http://rendertron

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "polymer-build": "npm-run-all 'polymer build {@}' --",
     "polymer-lint": "npm-run-all 'polymer lint {@}' --",
     "polymer-serve": "npm-run-all 'polymer serve {@}' --",
-    "prpl-server": "prpl-server --root build/ --host 0.0.0.0 --port 80",
+    "prpl-server": "prpl-server --root build/ --host 0.0.0.0 --port ${PORT:-80} $(if [ -n \"${BOT_PROXY:-}\" ]; then echo \"--bot-proxy ${BOT_PROXY}\"; fi)",
     "serve": "npm-run-all 'serve-examples {@}' --",
     "serve-examples": "./bin/serve $(if [ -z \"$*\" ]; then echo \"examples\"; fi)",
     "serve-live": "./bin/serve",


### PR DESCRIPTION
This will proxy bots if the environment variable is set. If the address
does not exist it falls back to serving directly. This will be used for
internal DNS usage in our production servers

## QA
(Need to run yarn locally to test as ./run can't forward the port from the exec command)
- `yarn install`
- `bower install`
- `PORT=8016 BOT_PROXY=http://fake-rendertron/render yarn run prpl-server`
- `curl -H http://localhost:8016` - Returns 200
- `curl -IH "User-Agent: Slackbot" http://localhost:8016"` - Will show a `ENOTFOUND` error in prpl-server output and return a 200 (a little slower)
