### PR TITLE
Disable automatic backurl

### DIFF
--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -153,11 +153,6 @@
       ],
 
       ready: function() {
-        // If client linked here AND referral wasn't within host, change backURL
-        if (document.referrer &&
-            document.referrer.indexOf(window.location.hostname) === -1) {
-          this.backURL = document.referrer;
-        }
         let el = document.querySelector('ubuntu-tutorials-app');
         el.addEventListener('google-codelab-ready', function(error) {
           this._attachFeedbackForm();


### PR DESCRIPTION
This makes the back button always go to the homepage, unless the backURL parameter is explicitly set.

## QA

1. Click on http://tutorials.ubuntu.com-pr-563.run.demo.haus/tutorial/kubeapps-on-canonical-kubernetes (or http://localhost:8016/tutorial/kubeapps-on-canonical-kubernetes)
2. click on the back button next to the title
3. Ensure you are moved to the homepage of tutorials and not github.com


