### PR TITLE
Update linter to check for duplicated tutorial ids

### DIFF
--- a/test/lint-metadata.js
+++ b/test/lint-metadata.js
@@ -13,9 +13,29 @@ var required_keys = [ 'id',
                  'author']
 
 var files = find.fileSync(/\.md$/,"tutorials");
+var tutorial_ids = []
 for(var i=0, len=files.length; i < len; i++){
   var f = gm.read(files[i]);
   validate(f, files[i]);
+  tutorial_ids.push(f.data.id)
+}
+duplicates_check(tutorial_ids);
+
+// Checks for duplicates in tutorials ids
+function duplicates_check(array) {
+  describe('The list of tutorials', function(){
+    it('doesn\'t contain duplicated IDs', function(done){
+      var sorted_arr = array.slice().sort();
+      var duplicates = [];
+      for (var i = 0; i < sorted_arr.length - 1; i++) {
+          if (sorted_arr[i + 1] == sorted_arr[i]) {
+              duplicates.push(sorted_arr[i]);
+          }
+      }
+      assert(duplicates.length == 0, `duplicates found: ${duplicates}`);
+      done();
+    });
+  });
 }
 
 // Validates metadata for each tutorial


### PR DESCRIPTION
A duplicated tutorial ID can lead to pretty bad things, such as a localized tutorial overriding the URL of the default one, if the translator has not checked if the ID was different from the original.

The metadata linter now checks for duplicates.

### QA

1. Change the ID of a tutorial to match the ID of another one
2. `./run tests` shoud fail