### PR TITLE
Ubuntu font self-serving

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
   <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://assets.ubuntu.com/v1/09460d9a-apple-touch-icon-72x72-precomposed.png" />
   <link rel="apple-touch-icon-precomposed" href="https://assets.ubuntu.com/v1/cc66da65-apple-touch-icon-precomposed.png" />
 
-  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Ubuntu:400,300,400italic,500,700|Ubuntu+Mono">
   <style>
+    @font-face{font-family:Ubuntu;font-style:normal;font-weight:300;src:url(https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:normal;font-weight:400;src:url(https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/7af50859-Ubuntu-R_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:italic;font-weight:300;src:url(https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/8be89d02-Ubuntu-LI_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:italic;font-weight:400;src:url(https://assets.ubuntu.com/v1/fca66073-ubuntu-ri-webfont.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/f0898c72-ubuntu-ri-webfont.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:normal;font-weight:100;src:url(https://assets.ubuntu.com/v1/7f100985-Ubuntu-Th_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/502cc3a1-Ubuntu-Th_W.woff) format("woff")}
     body {
       margin: 0;
       font-family: 'Ubuntu', sans-serif;

--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
   <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://assets.ubuntu.com/v1/09460d9a-apple-touch-icon-72x72-precomposed.png" />
   <link rel="apple-touch-icon-precomposed" href="https://assets.ubuntu.com/v1/cc66da65-apple-touch-icon-precomposed.png" />
 
+  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Ubuntu+Mono">
+  
   <style>
     @font-face{font-family:Ubuntu;font-style:normal;font-weight:300;src:url(https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:normal;font-weight:400;src:url(https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/7af50859-Ubuntu-R_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:italic;font-weight:300;src:url(https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/8be89d02-Ubuntu-LI_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:italic;font-weight:400;src:url(https://assets.ubuntu.com/v1/fca66073-ubuntu-ri-webfont.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/f0898c72-ubuntu-ri-webfont.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:normal;font-weight:100;src:url(https://assets.ubuntu.com/v1/7f100985-Ubuntu-Th_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/502cc3a1-Ubuntu-Th_W.woff) format("woff")}
     body {


### PR DESCRIPTION
This brings fonts served from assets.ubuntu.com as opposed to Google webfonts only. This fixes the bold Ubuntu font issue seen on Chromium-based browsers.

## QA

1. On Ubuntu, open https://tutorials.ubuntu.com in Chrome and Firefox, fonts on Chrome should look much bolder.
2. Now compare http://tutorials.ubuntu.com-pr-581.run.demo.haus/ in Chrome and Firefox, fonts should look much thinner (pretty close to Firefox on step 1)