### PR TITLE
Get search keywords from URL q param

### DIFF
--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -367,6 +367,12 @@
         this.updateMetadata();
       },
 
+      ready: function() {
+        if (this.route.__queryParams['q']) {
+          this.filterSearch = this.route.__queryParams['q'];
+        }
+      },
+
       updateMetadata: function() {
         this.fire('app-metadata', {
           title: 'Ubuntu tutorials',


### PR DESCRIPTION
If it exists, the index now passes the "q" parameter from the URL to the search field.

## QA

* Ensure http://tutorials.ubuntu.com-pr-586.run.demo.haus/?q=snapcraft fills up the search input with "snapcraft" and returns snapcraft related tutorials
* Ensure the correct search is applied when the search field is changed afterwards
* Ensure http://tutorials.ubuntu.com-pr-586.run.demo.haus/?q= returns all tutorials
* Ensure http://tutorials.ubuntu.com-pr-586.run.demo.haus/?q=foo returns no tutorials