### PR TITLE
Fix Ubuntu Forums URL in Livepatch tutorial

### DIFF
--- a/tutorials/server/enable-the-livepatch-service/enable-the-livepatch-service.md
+++ b/tutorials/server/enable-the-livepatch-service/enable-the-livepatch-service.md
@@ -101,7 +101,7 @@ Congratulations, you now have zero downtime kernel patching on your system!
 
 If you have a problem, we're ready to help! Check the following links:
 
-* [Ubuntu forums](https://community.ubuntu.com)
+* [Ubuntu Forums](https://ubuntuforums.org)
 * [Ask Ubuntu](https://askubuntu.com/)
 
 ### Further reading


### PR DESCRIPTION
Fix Ubuntu Forums URL in the Canonical Livepatch tutorial (ubuntuforums.org instead of community.ubuntu.com).

community.ubuntu.com page is not for technical support. While creating this tutorial, I didn't know about this and I gave a wrong URL. This pull request fixes it.