### PR TITLE
Render and build improvement

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <link rel="apple-touch-icon-precomposed" href="https://assets.ubuntu.com/v1/cc66da65-apple-touch-icon-precomposed.png" />
 
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Ubuntu+Mono">
-  
+
   <style>
     @font-face{font-family:Ubuntu;font-style:normal;font-weight:300;src:url(https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:normal;font-weight:400;src:url(https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/7af50859-Ubuntu-R_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:italic;font-weight:300;src:url(https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/8be89d02-Ubuntu-LI_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:italic;font-weight:400;src:url(https://assets.ubuntu.com/v1/fca66073-ubuntu-ri-webfont.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/f0898c72-ubuntu-ri-webfont.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:normal;font-weight:100;src:url(https://assets.ubuntu.com/v1/7f100985-Ubuntu-Th_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/502cc3a1-Ubuntu-Th_W.woff) format("woff")}
     body {
@@ -82,7 +82,7 @@
 
   <meta name="google-site-verification" content="0IvYwDQk61DQg67UU7CV7LfBnPchnsRSupJp83QOCh8" />
 </head>
-<body class="fullbleed">
+<body class="fullbleed" unresolved>
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -92,5 +92,6 @@
   <!-- End Google Tag Manager -->
 
   <ubuntu-tutorials-app></ubuntu-tutorials-app>
+
 </body>
 </html>

--- a/polymer.json
+++ b/polymer.json
@@ -20,7 +20,7 @@
   "builds": [{
     "name": "bundled",
     "bundle": true,
-    "js": {"minify": true},
+    "js": {"minify": true, "compile": true},
     "css": {"minify": true},
     "html": {"minify": true},
     "addServiceWorker": true,


### PR DESCRIPTION
Set unresolved attribute on body. It helps prevent flashing of unstyled content.
Once Polymer has loaded, it removes this attribute

Explicity set build option to compile Javascript as default.

## QA
- `./run` and check the site removes the unresolved attribute on load.
- `./run exec yarn polymer-build` should run without errors
