### PR TITLE
Render/speed improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,6 @@
   <link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://assets.ubuntu.com/v1/09460d9a-apple-touch-icon-72x72-precomposed.png" />
   <link rel="apple-touch-icon-precomposed" href="https://assets.ubuntu.com/v1/cc66da65-apple-touch-icon-precomposed.png" />
 
-  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400|Ubuntu+Mono">
-
   <style>
     @font-face{font-family:Ubuntu;font-style:normal;font-weight:300;src:url(https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/8619add2-Ubuntu-L_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:normal;font-weight:400;src:url(https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/7af50859-Ubuntu-R_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:italic;font-weight:300;src:url(https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/8be89d02-Ubuntu-LI_W.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:italic;font-weight:400;src:url(https://assets.ubuntu.com/v1/fca66073-ubuntu-ri-webfont.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/f0898c72-ubuntu-ri-webfont.woff) format("woff")}@font-face{font-family:Ubuntu;font-style:normal;font-weight:100;src:url(https://assets.ubuntu.com/v1/7f100985-Ubuntu-Th_W.woff2) format("woff2"),url(https://assets.ubuntu.com/v1/502cc3a1-Ubuntu-Th_W.woff) format("woff")}
     body {

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -327,13 +327,11 @@
             <div class="flex"></div>
           </div>
           <div class="horizontal layout wrap">
-            <template is="dom-if" if="[[!isEmpty]]">
-              <template is="dom-repeat" items="[[filteredTutorials]]" sort="[[_getSortFunction(filterSort)]]">
-                <codelabs-card heading="[[item.title]]" summary="[[item.summary]]" category="[[item.category]]"
-                              difficulty="[[item.difficulty]]" duration="[[item.duration}}" tags="[[item.tags]]"
-                              published="[[item.published]]" url="[[item.url]]"
-                              ></codelabs-card>
-              </template>
+            <template is="dom-repeat" items="[[filteredTutorials]]" sort="[[_getSortFunction(filterSort)]]">
+              <codelabs-card heading="[[item.title]]" summary="[[item.summary]]" category="[[item.category]]"
+                            difficulty="[[item.difficulty]]" duration="[[item.duration}}" tags="[[item.tags]]"
+                            published="[[item.published]]" url="[[item.url]]"
+                            ></codelabs-card>
             </template>
             <template is="dom-if" if="[[isEmpty]]">
               <div class="no-results">

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -226,21 +226,6 @@
         }
       },
 
-      _codelabsInfoHandler: function(event) {
-        this.categoriesmap = event.detail.response['categories'];
-        this.eventsmap = event.detail.response['events'];
-        event.detail.response['codelabs'].forEach(function(codelab) {
-          this.push('codelabs', codelab);
-        }, this);
-
-        // Force a binding update. Officially recommended, really!
-        // https://www.polymer-project.org/1.0/docs/devguide/model-data#override-dirty-check
-        let codelabs = this.codelabs;
-        this.codelabs = [];
-        this.codelabs = codelabs;
-        this._updateMetadata();
-      },
-
       _loadTutorial: function(e, url) {
         this._updateMetadata();
         const resp = e.detail.response;

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -162,6 +162,7 @@
       observers: [
         '_handleLoading(loading, url)',
         '_onPageChange(routeData.codelab)',
+        '_updateMetadata(routeData.codelab, codelabs)',
       ],
 
       ready: function() {
@@ -210,7 +211,7 @@
       },
 
       _updateMetadata: function() {
-        if (!this.codelabs) {
+        if (!this.codelabs || !this.routeData || !this.routeData.codelab) {
           return;
         }
         let currentUrl = this.routeData.codelab;


### PR DESCRIPTION
Couple of speed improvements:

- Remove unneeded Google Fonts import
- Load page title on tutorials a little quicker, as soon as the required data is available
- Remove superfluous template tag on the front page

## QA

- `./run` the server.
- Frontpage cards should load
- Check a tutorial page to make sure the page title is set