### PR TITLE
Extend prpl-server with SEO magic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ WORKDIR /srv
 ADD . .
 
 # Setup commands to run server
-ENTRYPOINT ["yarn", "run", "prpl-server"]
+ENTRYPOINT ["yarn", "run", "start-server"]
 CMD [""]

--- a/index.html
+++ b/index.html
@@ -77,8 +77,6 @@
   </script>
 
   <link rel="import" href="src/ubuntu-tutorials-app.html">
-
-  <meta name="google-site-verification" content="0IvYwDQk61DQg67UU7CV7LfBnPchnsRSupJp83QOCh8" />
 </head>
 <body class="fullbleed" unresolved>
   <!-- Google Tag Manager -->

--- a/package.json
+++ b/package.json
@@ -40,11 +40,14 @@
     "gray-matter": "^3.1.1",
     "mocha": "^4.0.1",
     "mocha-minimalist-reporter": "^1.1.0",
-    "npm-run-all": "^4.0.2",
     "polymer-cli": "^1.5.7",
     "prpl-server": "^1.0.0",
     "stylelint": "7.13.0",
     "stylelint-config-polymer": "^0.0.1",
     "stylelint-processor-html": "^1.0.0"
+  },
+  "dependencies": {
+    "npm-run-all": "^4.0.2",
+    "sitemap": "^1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "polymer-build": "npm-run-all 'polymer build {@}' --",
     "polymer-lint": "npm-run-all 'polymer lint {@}' --",
     "polymer-serve": "npm-run-all 'polymer serve {@}' --",
-    "prpl-server": "prpl-server --root build/ --host 0.0.0.0 --port ${PORT:-80} $(if [ -n \"${BOT_PROXY:-}\" ]; then echo \"--bot-proxy ${BOT_PROXY}\"; fi)",
+    "prpl-server": "echo 'ERROR: Please use start-server script.' && exit 1",
     "serve": "npm-run-all 'serve-examples {@}' --",
     "serve-examples": "./bin/serve $(if [ -z \"$*\" ]; then echo \"examples\"; fi)",
     "serve-live": "./bin/serve",
+    "start-server": "node ./server.js --root build/ --host 0.0.0.0 --port ${PORT:-80} $(if [ -n \"${BOT_PROXY:-}\" ]; then echo \"--bot-proxy ${BOT_PROXY}\"; fi)",
     "test": "npm-run-all lint-js lint-polymer lint-style lint-content"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "stylelint-processor-html": "^1.0.0"
   },
   "dependencies": {
+    "cheerio": "^1.0.0-rc.2",
+    "express-interceptor": "^1.2.0",
     "npm-run-all": "^4.0.2",
     "sitemap": "^1.13.0"
   }

--- a/polymer.json
+++ b/polymer.json
@@ -15,7 +15,8 @@
   "extraDependencies": [
     "api/**/*",
     "bower_components/webcomponentsjs/webcomponents-lite.min.js",
-    "manifest.json"
+    "manifest.json",
+    "robots.txt"
   ],
   "builds": [{
     "name": "bundled",

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+sitemap: https://tutorials.ubuntu.com/sitemap.xml

--- a/server.js
+++ b/server.js
@@ -1,0 +1,186 @@
+/**
+ * This file is modified from Polymer's prpl-server project. The original file
+ * can be found at:
+ * https://github.com/Polymer/prpl-server-node/blob/master/src/cli.ts
+ *
+ * This file is licensed under a BSD license from Polymer:
+ *
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+"use strict";
+
+let compression = require('compression')
+let express = require('express');
+let fs = require('fs');
+let path = require('path');
+
+let prpl = require('prpl-server');
+
+const commandLineArgs = require('command-line-args');
+const commandLineUsage = require('command-line-usage');
+const ansi = require('ansi-escape-sequences');
+const rendertron = require('rendertron-middleware');
+
+const argDefs = [
+  {
+    name: 'help',
+    type: Boolean,
+    description: 'Print this help text.',
+  },
+  {
+    name: 'version',
+    type: Boolean,
+    description: 'Print the installed version.',
+  },
+  {
+    name: 'host',
+    type: String,
+    defaultValue: '127.0.0.1',
+    description: 'Listen on this hostname (default 127.0.0.1).',
+  },
+  {
+    name: 'port',
+    type: Number,
+    defaultValue: 8080,
+    description: 'Listen on this port; 0 for random (default 8080).'
+  },
+  {
+    name: 'root',
+    type: String,
+    defaultValue: '.',
+    description: 'Serve files relative to this directory (default ".").',
+  },
+  {
+    name: 'config',
+    type: String,
+    description:
+        'JSON configuration file (default "<root>/polymer.json" if exists).',
+  },
+  {
+    name: 'https-redirect',
+    type: Boolean,
+    description:
+        'Redirect HTTP requests to HTTPS with a 301. Assumes same hostname ' +
+        'and default port (443). Trusts X-Forwarded-* headers for detecting ' +
+        'protocol and hostname.',
+  },
+  {
+    name: 'bot-proxy',
+    type: String,
+    description: 'Proxy requests from bots/crawlers to this URL. See ' +
+        'https://github.com/GoogleChrome/rendertron for more details.',
+  },
+  {
+    name: 'cache-control',
+    type: String,
+    description:
+        'The Cache-Control header to send for all requests except the ' +
+        'entrypoint (default from config file or "max-age=60").',
+  },
+];
+
+
+const args = commandLineArgs(argDefs);
+
+if (args.help) {
+  console.log(commandLineUsage([
+    {
+      header: `[magenta]{prpl-server}`,
+      content: 'https://github.com/Polymer/prpl-server-node',
+    },
+    {
+      header: `Options`,
+      optionList: argDefs,
+    }
+  ]));
+  return;
+}
+
+if (args.version) {
+  console.log(require('../package.json').version);
+  return;
+}
+
+if (!args.host) {
+  throw new Error('invalid --host');
+}
+if (isNaN(args.port)) {
+  throw new Error('invalid --port');
+}
+if (!args.root) {
+  throw new Error('invalid --root');
+}
+
+// If specified explicitly, a missing config file will error. Otherwise, try
+// the default location and only warn when it's missing.
+if (!args.config) {
+  const p = path.join(args.root, 'polymer.json');
+  if (fs.existsSync(p)) {
+    args.config = p;
+  } else {
+    console.warn('WARNING: No config found.');
+  }
+}
+let config = {};
+if (args.config) {
+  console.info(`Loading config from "${args.config}".`);
+  config = JSON.parse(fs.readFileSync(args.config, 'utf8'));
+}
+
+if (args['cache-control']) {
+  config.cacheControl = args['cache-control'];
+};
+
+const app = express();
+
+// Trust X-Forwarded-* headers so that when we are behind a reverse proxy,
+// our connection information is that of the original client (according to
+// the proxy), not of the proxy itself. We need this for HTTPS redirection
+// and bot rendering.
+app.set('trust proxy', true);
+
+if (args['https-redirect']) {
+  console.info(`Redirecting HTTP requests to HTTPS.`);
+  app.use((req, res, next) => {
+    if (req.secure) {
+      next();
+      return;
+    }
+    res.redirect(301, `https://${req.hostname}${req.url}`);
+  });
+}
+
+app.use(compression());
+
+if (args['bot-proxy']) {
+  console.info(`Proxying bots to "${args['bot-proxy']}".`);
+  app.use(rendertron.makeMiddleware({
+    proxyUrl: args['bot-proxy'],
+    injectShadyDom: true,
+  }));
+}
+
+app.use(prpl.makeHandler(args.root, config));
+
+const server = app.listen(args.port, args.host, () => {
+  const addr = server.address();
+  let urlHost = addr.address;
+  if (addr.family === 'IPv6') {
+    urlHost = '[' + urlHost + ']';
+  }
+  console.log();
+  console.log(ansi.format('[magenta bold]{prpl-server} listening'));
+  console.log(ansi.format(`[blue]{http://${urlHost}:${addr.port}}`));
+  console.log();
+});

--- a/server.js
+++ b/server.js
@@ -174,6 +174,8 @@ const app = express();
 // and bot rendering.
 app.set('trust proxy', true);
 
+app.set('env', 'production')
+
 if (args['https-redirect']) {
   console.info(`Redirecting HTTP requests to HTTPS.`);
   app.use((req, res, next) => {
@@ -194,6 +196,15 @@ if (args['bot-proxy']) {
     injectShadyDom: true,
   }));
 }
+
+// Serve API folder directly
+app.use('/api', express.static(
+  path.join(__dirname, 'api'),
+  {
+    // Return a 404 if api file does not exist
+    fallthrough: false,
+  }
+));
 
 const tutorialsSitemap = generateSitemap();
 app.get('/sitemap.xml', function(req, res) {

--- a/server.js
+++ b/server.js
@@ -206,6 +206,18 @@ app.use('/api', express.static(
   }
 ));
 
+// If a tutorial does not exist, return a 404 header
+app.use('/tutorial/:id', function(req, res, next){
+  const id = req.params.id;
+  let metadata = tutorialsData.filter(function(metadata) {
+    return metadata.id === id;
+  })[0];
+  if (!metadata) {
+    res.status(404);
+  }
+  next()
+});
+
 const tutorialsSitemap = generateSitemap();
 app.get('/sitemap.xml', function(req, res) {
   res.header('Content-Type', 'application/xml');

--- a/server.js
+++ b/server.js
@@ -159,6 +159,7 @@ const tutorialsAPIPath = path.join(__dirname, 'api', 'codelabs.json');
 const tutorialsData = require(tutorialsAPIPath).codelabs;
 let isError = false;
 let isTutorial = false;
+let isFileRequest = false;
 let tutorialExists = false;
 let tutorialMetadata = false;
 
@@ -244,7 +245,7 @@ const applyMetadata = interceptor(function(req, res){
     // Only HTML responses will be intercepted
     isInterceptable: function(){
       const isHTML = /text\/html/.test(res.get('Content-Type'));
-      return !isError && isHTML;
+      return !isError && !isFileRequest && isHTML;
     },
     // Appends a paragraph at the end of the response body
     intercept: function(body, send) {
@@ -293,6 +294,13 @@ if (args['bot-proxy']) {
     injectShadyDom: true,
   }));
 }
+
+app.use('*.html', function(req, res, next) {
+  // If the path ends with .html, it is a direct file request
+  // and we should avoid modifying the output
+  isFileRequest = true;
+  next()
+});
 
 // Serve API folder directly
 app.use('/api', express.static(

--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -220,8 +220,15 @@
         })[0];
         if (metadata !== undefined) {
           this.fire('app-metadata', {
-            title: metadata.title + ' | Ubuntu tutorials',
-            description: metadata.summary,
+            'title': metadata.title + ' | Ubuntu tutorials',
+            'description': metadata.summary,
+            'author': metadata.author || '',
+            'og:description': metadata.summary || '',
+            'og:image': metadata.image || '',
+            'og:title': metadata.title + ' | Ubuntu tutorials',
+            'og:type': 'article',
+            'article:author': metadata.author || '',
+            'article:published_time': metadata.published || '',
           });
         }
       },

--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -125,6 +125,16 @@
             if (currentPage.updateMetadata) {
               currentPage.updateMetadata();
             }
+            // We don't currently manage canonical URLs and the may be set
+            // from server. This will remove them for now on page changes.
+            const canonicalTag = document.querySelectorAll(
+              'link[rel="canonical"]'
+            );
+            if (canonicalTag.length > 0) {
+              canonicalTag.forEach((node) => {
+                node.parentNode.removeChild(node);
+              });
+            }
           },
           function onImportError(event) {
             this._loadErrorPage();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5912,6 +5912,13 @@ sinon@^2.3.5:
     text-encoding "0.6.4"
     type-detect "^4.0.0"
 
+sitemap@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-1.13.0.tgz#569cbe2180202926a62a266cd3de09c9ceb43f83"
+  dependencies:
+    underscore "^1.7.0"
+    url-join "^1.1.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -6635,7 +6642,7 @@ underscore.string@3.3.4:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
-underscore@^1.8.3:
+underscore@^1.7.0, underscore@^1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
@@ -6712,6 +6719,10 @@ upper-case@^1.1.1:
 urijs@1.16.1, urijs@^1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.16.1.tgz#859ad31890f5f9528727be89f1932c94fb4731e2"
+
+url-join@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,6 +1405,10 @@ body-parser@1.18.2, body-parser@^1.17.2:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -1629,6 +1633,17 @@ chalk@~0.4.0:
 check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 chownr@^1.0.1:
   version "1.0.1"
@@ -2000,6 +2015,15 @@ css-rule-stream@^1.1.0:
     ldjson-stream "^1.2.1"
     through2 "^0.6.3"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
 css-slam@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/css-slam/-/css-slam-2.0.2.tgz#356ab778cae1a777f35842e7192d5f279cd0153a"
@@ -2016,6 +2040,10 @@ css-tokenize@^1.0.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^1.0.33"
+
+css-what@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
 cssbeautify@^0.3.1:
   version "0.3.1"
@@ -2234,7 +2262,7 @@ doiuse@^2.4.1:
     through2 "^0.6.3"
     yargs "^3.5.4"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
@@ -2269,6 +2297,13 @@ domhandler@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
   dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
     domelementtype "1"
 
 domutils@^1.5.1:
@@ -2704,6 +2739,12 @@ expand-tilde@^1.2.2:
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-1.2.2.tgz#0b81eba897e5a3d31d1c3d102f8f01441e559449"
   dependencies:
     os-homedir "^1.0.1"
+
+express-interceptor@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/express-interceptor/-/express-interceptor-1.2.0.tgz#33460a8e11dce7e5a022caf555d377e45ddb822a"
+  dependencies:
+    debug "^2.2.0"
 
 express@^4.15.2, express@^4.15.3:
   version "4.16.2"
@@ -4187,7 +4228,7 @@ lodash@^3.0.0, lodash@^3.0.1, lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.8.0:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.8.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4590,6 +4631,12 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
+
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
@@ -4780,6 +4827,12 @@ parse-passwd@^1.0.0:
 parse5@^2.2.1, parse5@^2.2.2, parse5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-2.2.3.tgz#0c4fc41c1000c5e6b93d48b03f8083837834e9f6"
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 parseqs@0.0.5:
   version "0.0.5"


### PR DESCRIPTION
This extends the prpl-server used in production. It adds mittleware to set headers and HTML head.

The key features:
- Send correct 404 headers on non existant `/tutorials/*` and `/api/*` URLs.
- Set metadata in the output, looking up correct data from codelabs API.
- Add a `sitemap.xml` to link to every tutorial, and a robots.txt to link to sitemap


## QA
QA'ing this will require not using the ./run script.

- `yarn run clean`
- `yarn install`
- `yarn run build-all`
- `PORT=8081 yarn run start-server`

I have been testing metadata output with:
`http http://0.0.0.0:8081/tutorial/install-openstack-with-conjure-up\#0 -p hb | rg -e 'HTTP.*$' -e '<title>[^<]*</title>' -e '<meta[^>]*>' -e '<[^<>]*canonical[^>]*>' -o`

(Using `httpie` for web request, and `rg`/`ripgrep` is a really nice grep replacement)

```
HTTP/1.1 200 OK
<meta charset="utf-8">
<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1,user-scalable=yes">
<title>Install single-server OpenStack with conjure-up | Ubuntu tutorials</title>
<meta name="description" content="Learn how to deploy OpenStack on a single machine using the conjure-up deployment tool.">
<meta name="theme-color" content="#dd4814">
<meta name="google-site-verification" content="0IvYwDQk61DQg67UU7CV7LfBnPchnsRSupJp83QOCh8">
<meta name="og:title" content="Install single-server OpenStack with conjure-up | Ubuntu tutorials">
<meta name="og:type" content="article">
<meta name="og:url" content="https://tutorials.ubuntu.com/tutorial/install-openstack-with-conjure-up">
<meta name="author" content="Konrad Krawiec">
<meta name="article:author" content="Konrad Krawiec">
<meta name="article:published_time" content="2018-01-13T00:00:01Z">
<meta name="og:description" content="Learn how to deploy OpenStack on a single machine using the conjure-up deployment tool.">
<link rel="canonical" href="https://tutorials.ubuntu.com/tutorial/install-openstack-with-conjure-up">

```