### PR TITLE
Add image metadata in examples

### DIFF
--- a/examples/example-tutorial.md
+++ b/examples/example-tutorial.md
@@ -76,6 +76,7 @@ categories: community
 tags: guidelines, guide, write, contribute
 difficulty: 2
 status: published
+image: https://foo.png
 feedback_url: https://github.com/canonical-websites/tutorials.ubuntu.com/issues
 published: 2017-01-13
 author: Canonical Web Team <webteam@canonical.com>
@@ -98,6 +99,7 @@ Let's have a look at each field:
      * **5**: Ubuntu sysadmin/developer- very familiar with most aspects of the operating system and can be expected to know details about its inner workings
 
  * **status**: `draft` or `published`
+ * **image** (optional): an absolute link to an image that will be used when sharing the tutorial on social networks. Preferred dimensions: width should be over 1000px with a 16:9 or 16:10 ratio.
  * **feedback_url**: where to report bugs and give feedback about this tutorial. Unless you have very specific requirements, this should be: `https://github.com/canonical-websites/tutorials.ubuntu.com/issues`.
  * **author**: the name and email address between brackets of the author of the tutorial. If you don't intend to maintain this tutorial after publication, please use `Canonical Web Team <webteam@canonical.com>`
  * **published**: a date in YYYY-MM-DD format, to be updated after any major change to the tutorial

--- a/tutorials/community/tutorial-guidelines.md
+++ b/tutorials/community/tutorial-guidelines.md
@@ -76,6 +76,7 @@ categories: community
 tags: guidelines, guide, write, contribute
 difficulty: 2
 status: published
+image: https://foo.png
 feedback_url: https://github.com/canonical-websites/tutorials.ubuntu.com/issues
 published: 2017-01-13
 author: Canonical Web Team <webteam@canonical.com>
@@ -98,6 +99,7 @@ Let's have a look at each field:
      * **5**: Ubuntu sysadmin/developer- very familiar with most aspects of the operating system and can be expected to know details about its inner workings
 
  * **status**: `draft` or `published`
+ * **image** (optional): an absolute link to an image that will be used when sharing the tutorial on social networks. Preferred dimensions: width should be over 1000px with a 16:9 or 16:10 ratio.
  * **feedback_url**: where to report bugs and give feedback about this tutorial. Unless you have very specific requirements, this should be: `https://github.com/canonical-websites/tutorials.ubuntu.com/issues`.
  * **author**: the name and email address between brackets of the author of the tutorial. If you don't intend to maintain this tutorial after publication, please use `Canonical Web Team <webteam@canonical.com>`
  * **published**: a date in YYYY-MM-DD format, to be updated after any major change to the tutorial


### PR DESCRIPTION
This adds the "image" metadata field to the guidelines and example.
* This optional field takes an image link that will be used in opengraph metadata when building the static page served to bots and scripts.

The two prerequisites commits to handle this metadata in the md parser have been merged upstream: 
* https://github.com/didrocks/codelab-ubuntu-tools/pull/1
* https://github.com/Ubuntu/tutorial-deployment/pull/4

## QA

* Add an image field to a tutorial
* run `npm run build-all`
* run `PORT=8081 yarn run start-server`
* Go to `localhost:8081/<tutorial you changed>`, inspect meta tags of the page and ensure "og:image" is correctly set.