### PR TITLE
Make main container focusable so is keyboard accessible

### DIFF
--- a/src/ubuntu-tutorials-app.html
+++ b/src/ubuntu-tutorials-app.html
@@ -99,6 +99,17 @@
         el.addEventListener('iron-ajax-error', function(error) {
           this._loadErrorPage();
         });
+
+        this.tabIndex = 0;
+
+        this.addEventListener('focus', function() {
+          let mainContainer = document.getElementById('mainContainer');
+
+          if (mainContainer) {
+            mainContainer.setAttribute('tabindex', 0);
+            mainContainer.focus();
+          }
+        });
       },
 
       _loadPage: function _loadPage(page) {


### PR DESCRIPTION
## Done

- Apply tabindex to app component and listen for focus and apply focus to main container element

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)

## Issue / Card
- [Fixes #615](https://github.com/canonical-websites/tutorials.ubuntu.com/issues/615#event-1505915524) 

