### PR TITLE
Fix typo in gpg --list-keys call

### DIFF
--- a/tutorials/desktop/how-to-verify-ubuntu/how-to-verify-ubuntu.md
+++ b/tutorials/desktop/how-to-verify-ubuntu/how-to-verify-ubuntu.md
@@ -65,7 +65,7 @@ You can check the commands work as expected by running the following:
 
 
 ```bash
-gpg --list keys
+gpg --list-keys
 ```
 
 If this is the first time you have run `gpg`, this will create a trust database for the current user.


### PR DESCRIPTION
This fixes a minor typo in the tutorial.