### PR TITLE
Add redirects for renamed tutorials

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
     "express-interceptor": "^1.2.0",
+    "express-simple-redirect": "^1.0.1",
     "npm-run-all": "^4.0.2",
     "sitemap": "^1.13.0"
   }

--- a/redirects.json
+++ b/redirects.json
@@ -1,0 +1,6 @@
+{
+  "/tutorial/graphical-snaps/": "/tutorial/secure-ubuntu-kiosk",
+  "/tutorial/graphical-snaps": "/tutorial/secure-ubuntu-kiosk",
+  "/tutorial/graphical-snaps-xwayland/": "/tutorial/x11-kiosk",
+  "/tutorial/graphical-snaps-xwayland": "/tutorial/x11-kiosk"
+}

--- a/server.js
+++ b/server.js
@@ -32,8 +32,11 @@ const commandLineUsage = require('command-line-usage');
 const ansi = require('ansi-escape-sequences');
 const cheerio     = require('cheerio');
 const interceptor = require('express-interceptor');
+const redirect = require('express-simple-redirect');
 const rendertron = require('rendertron-middleware');
 const sitemap = require('sitemap');
+
+const redirectsConfig = require('./redirects.json');
 
 const argDefs = [
   {
@@ -289,6 +292,9 @@ app.use(compression());
 
 // Add the interceptor middleware
 app.use(applyMetadata);
+
+// Handle redirects
+app.use(redirect(redirectsConfig));
 
 if (args['bot-proxy']) {
   console.info(`Proxying bots to "${args['bot-proxy']}".`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,6 +2746,10 @@ express-interceptor@^1.2.0:
   dependencies:
     debug "^2.2.0"
 
+express-simple-redirect@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/express-simple-redirect/-/express-simple-redirect-1.0.1.tgz#589176c6423d2acc08e9475225801c6bb1c99f31"
+
 express@^4.15.2, express@^4.15.3:
   version "4.16.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.2.tgz#e35c6dfe2d64b7dca0a5cd4f21781be3299e076c"


### PR DESCRIPTION
## Done

Add redirects to work with renamed tutorials in PR #828.
This should be merged alongside that PR.


## QA

- Check out this feature branch
- Build `./run exec yarn run build-all`
- Run the site using the command `./run exec -p 8016 yarn run start-server`
- Check the redirects are correct with curl

```sh
# /tutorial/graphical-snaps → /tutorial/secure-ubuntu-kiosk
curl -I localhost:8016/tutorial/graphical-snaps

# /tutorial/graphical-snaps-xwayland → /tutorial/x11-kiosk
curl -I localhost:8016/tutorial/graphical-snaps
```
