### PR TITLE
Update redirects to keep GET query

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.2",
     "express-interceptor": "^1.2.0",
-    "express-simple-redirect": "^1.0.1",
+    "express-redirect": "^1.2.2",
     "npm-run-all": "^4.0.2",
     "sitemap": "^1.13.0"
   }

--- a/redirects.json
+++ b/redirects.json
@@ -1,6 +1,4 @@
 {
-  "/tutorial/graphical-snaps/": "/tutorial/secure-ubuntu-kiosk",
   "/tutorial/graphical-snaps": "/tutorial/secure-ubuntu-kiosk",
-  "/tutorial/graphical-snaps-xwayland/": "/tutorial/x11-kiosk",
   "/tutorial/graphical-snaps-xwayland": "/tutorial/x11-kiosk"
 }

--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ const commandLineUsage = require('command-line-usage');
 const ansi = require('ansi-escape-sequences');
 const cheerio     = require('cheerio');
 const interceptor = require('express-interceptor');
-const redirect = require('express-simple-redirect');
+const redirect = require('express-redirect');
 const rendertron = require('rendertron-middleware');
 const sitemap = require('sitemap');
 
@@ -294,7 +294,15 @@ app.use(compression());
 app.use(applyMetadata);
 
 // Handle redirects
-app.use(redirect(redirectsConfig));
+redirect(app);
+
+Object.keys(redirectsConfig).forEach(function (key) {
+  app.redirect(
+    key,
+    redirectsConfig[key],
+    302, true
+  );
+});
 
 if (args['bot-proxy']) {
   console.info(`Proxying bots to "${args['bot-proxy']}".`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,9 +2746,11 @@ express-interceptor@^1.2.0:
   dependencies:
     debug "^2.2.0"
 
-express-simple-redirect@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/express-simple-redirect/-/express-simple-redirect-1.0.1.tgz#589176c6423d2acc08e9475225801c6bb1c99f31"
+express-redirect@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/express-redirect/-/express-redirect-1.2.2.tgz#6df98e99ee16ca2a1a7d6e4bb663dd6bf87e599c"
+  dependencies:
+    sanitize-arguments "~2.0"
 
 express@^4.15.2, express@^4.15.3:
   version "4.16.2"
@@ -5765,6 +5767,10 @@ safe-buffer@^5.0.1, safe-buffer@~5.0.1:
 samsam@1.x, samsam@^1.1.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+
+sanitize-arguments@~2.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/sanitize-arguments/-/sanitize-arguments-2.0.3.tgz#5bd8340bcd5bf060cbee9a776186cc71bba8b84f"
 
 sauce-connect-launcher@^1.0.0:
   version "1.2.2"


### PR DESCRIPTION
## Done

Update redirects to keep GET query


## QA

- Check out this feature branch
- Build `./run exec yarn run build-all`
- Run the site using the command `./run exec -p 8016 yarn run start-server`
- Check the redirects are correct with curl, including slash and get parameters

```sh
# /tutorial/graphical-snaps → /tutorial/secure-ubuntu-kiosk
curl -I localhost:8016/tutorial/graphical-snaps
curl -I localhost:8016/tutorial/graphical-snaps/
curl -I localhost:8016/tutorial/graphical-snaps?keep-this

# /tutorial/graphical-snaps-xwayland → /tutorial/x11-kiosk
curl -I localhost:8016/tutorial/graphical-snaps
curl -I localhost:8016/tutorial/graphical-snaps/
curl -I localhost:8016/tutorial/graphical-snaps?alsokeep=this&this=aswell
```
