### PR TITLE
[iot] fix internal links in ubuntu-kiosk

### DIFF
--- a/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/electron-kiosk.md
@@ -22,9 +22,9 @@ duration: 1:00
 
 ### What you'll learn
 
-In this tutorial we will create a snap of a HTML5/Electron application to act as the graphical user interface for an IoT or kiosk device. For the introduction to this tutorial series and the Mir display server, please visit [here](tutorial/secure-ubuntu-kiosk).
+In this tutorial we will create a snap of a HTML5/Electron application to act as the graphical user interface for an IoT or kiosk device. For the introduction to this tutorial series and the Mir display server, please visit [here](/tutorial/secure-ubuntu-kiosk).
 
-This tutorial assumes you are familiar with the material in [Make an X11-based Kiosk Snap](tutorial/x11-kiosk).
+This tutorial assumes you are familiar with the material in [Make an X11-based Kiosk Snap](/tutorial/x11-kiosk).
 
 
 ### What you'll need
@@ -34,7 +34,7 @@ This tutorial assumes you are familiar with the material in [Make an X11-based K
 *   An Ubuntu desktop running any current release of Ubuntu or an Ubuntu Virtual Machine on another OS.
 *   A 'Target Device' from one of the following:
     *   **A device running [Ubuntu Core](https://www.ubuntu.com/core).**<br />
-[This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](https://tutorials.ubuntu.com/tutorial/create-your-own-core-image).
+[This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
 `snap install --beta ubuntu-core-vm --devmode`
@@ -61,7 +61,7 @@ Currently Electron does not have Wayland support, so we will use a tiny intermed
 ![electron-snap-architecture](images/electron-snap-architecture.png)
 
 
-[Click here](tutorial/x11-kiosk) for more information on this architecture.
+[Click here](/tutorial/x11-kiosk) for more information on this architecture.
 
 
 ## Snapping Electron apps
@@ -246,7 +246,7 @@ snapcraft cleanbuild
 ```
 
 
-(for building for other architectures, [follow this guide](tutorial/wayland-kiosk#building-for-different-architectures))
+(for building for other architectures, [follow this guide](/tutorial/wayland-kiosk#13))
 
 
 ## Deploying on a Device

--- a/tutorials/iot/ubuntu-kiosk/secure-ubuntu-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/secure-ubuntu-kiosk.md
@@ -40,7 +40,7 @@ How to create a graphical kiosk on Ubuntu Core running a single full-screen demo
 *   An Ubuntu desktop running any current release of Ubuntu or an Ubuntu Virtual Machine on another OS.
 *   A 'Target Device' from one of the following:
     *   **A device running [Ubuntu Core](https://www.ubuntu.com/core).**<br />
-[This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](https://tutorials.ubuntu.com/tutorial/create-your-own-core-image).
+[This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a Virtual Machine (VM)**
 You don't need to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
 `snap install --beta ubuntu-core-vm --devmode`
@@ -104,7 +104,7 @@ Using snapd interfaces your app can securely connect to Mir using the Wayland pr
 
 duration: 5:00
 
-This step assumes you have [Ubuntu Core installed and have SSHed into it](#what-youll-need).
+This step assumes you have [Ubuntu Core installed and have SSHed into it](#0).
 
 Install the "mir-kiosk" snap:
 
@@ -124,7 +124,7 @@ snap install --beta chromium-mir-kiosk
 ```
 
 
-and you should see a fullscreen webpage in your VM! (There are some configuration options in the snap, to find out more about this snap's options, [click here](tutorial/ubuntu-web-kiosk)).
+and you should see a fullscreen webpage in your VM! (There are some configuration options in the snap, to find out more about this snap's options, [click here](/tutorial/ubuntu-web-kiosk)).
 
 
 ## Building your own Kiosk Snap
@@ -137,6 +137,6 @@ We have written up a series of tutorials to address each of these possibilities.
 
 
 
-1.  [Make a Wayland-native Kiosk Snap](tutorial/wayland-kiosk)
-1.  [Make an X11-native Kiosk Snap](tutorial/x11-kiosk)
-1.  [Make an HTML5/Electron-based Kiosk Snap](tutorial/electron-kiosk)
+1.  [Make a Wayland-native Kiosk Snap](/tutorial/wayland-kiosk)
+1.  [Make an X11-native Kiosk Snap](/tutorial/x11-kiosk)
+1.  [Make an HTML5/Electron-based Kiosk Snap](/tutorial/electron-kiosk)

--- a/tutorials/iot/ubuntu-kiosk/ubuntu-web-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/ubuntu-web-kiosk.md
@@ -25,7 +25,7 @@ Since these devices are often left unattended for long periods of time, and run 
 
 This can provide a tightly integrated solution for display signage purposes, or by integrating touchscreen or keyboard capabilities, serves as a secure interactive web kiosk.
 
-Note: `chromium-mir-kiosk` is provided as-is, as a Proof-of-Concept only, not meant for production use. For information on how to roll out your own kiosk application, please see [this guide](tutorial/secure-ubuntu-kiosk) and [talk to us](https://www.ubuntu.com/internet-of-things/contact-us)!
+Note: `chromium-mir-kiosk` is provided as-is, as a Proof-of-Concept only, not meant for production use. For information on how to roll out your own kiosk application, please see [this guide](/tutorial/secure-ubuntu-kiosk) and [talk to us](https://www.ubuntu.com/internet-of-things/contact-us)!
 
 
 ### What you'll learn
@@ -40,7 +40,7 @@ How to install a demo web kiosk or web display on Ubuntu Core, and configure it 
 *   An Ubuntu desktop running any current release of Ubuntu
 *   A 'Target Device' from one of the following:
     *   **A device running [Ubuntu Core](https://www.ubuntu.com/core).**<br />
-[This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](https://tutorials.ubuntu.com/tutorial/create-your-own-core-image).
+[This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
 `snap install --beta ubuntu-core-vm --devmode`

--- a/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/wayland-kiosk.md
@@ -22,7 +22,7 @@ duration: 1:00
 
 ### What you'll learn
 
-In this tutorial we will create a snap of a Wayland-native application to act as the graphical user interface for an IoT or kiosk device. For the introduction to this tutorial series and the Mir display server please visit [here](tutorial/secure-ubuntu-kiosk).
+In this tutorial we will create a snap of a Wayland-native application to act as the graphical user interface for an IoT or kiosk device. For the introduction to this tutorial series and the Mir display server please visit [here](/tutorial/secure-ubuntu-kiosk).
 
 We will walk through the process for a simple application, solving common problems along the way.
 
@@ -37,7 +37,7 @@ positive
 *   An Ubuntu desktop running any current release of Ubuntu or an Ubuntu Virtual Machine on another OS.
 *   A 'Target Device' from one of the following:
     *   **A device running [Ubuntu Core](https://www.ubuntu.com/core).**<br />
-[This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](https://tutorials.ubuntu.com/tutorial/create-your-own-core-image).
+[This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
 `snap install --beta ubuntu-core-vm --devmode`
@@ -75,7 +75,7 @@ positive
 : Native support for Wayland is the simplest case, as the application can talk to Mir directly.
 
 negative
-: If your application does not use the above toolkits, or fails to run with Wayland, fret not! In [this tutorial we will describe how to snap X11-based applications](tutorial/x11-kiosk).
+: If your application does not use the above toolkits, or fails to run with Wayland, fret not! In [this tutorial we will describe how to snap X11-based applications](/tutorial/x11-kiosk).
 
 
 ## Preparation
@@ -133,7 +133,7 @@ This command runs a Mir server, and executes your application in a Wayland envir
 
 You should see a window pop up - Mir is running in this window (Mir-on-X) - and if your application supports Wayland, your application should appear _inside_ this window.
 
-If your application fails to start, or appears outside the Mir window, it may require X11 after all. To snap it, [follow this guide instead](tutorial/x11-kiosk).
+If your application fails to start, or appears outside the Mir window, it may require X11 after all. To snap it, [follow this guide instead](/tutorial/x11-kiosk).
 
 
 ## Introducing glmark2-wayland
@@ -668,7 +668,7 @@ duration: 3:00
 
 The goal here is to have our graphical snap running full-screen on your device.
 
-Before we proceed, you need to have Ubuntu Core [already running on your device](#what-youll-need).
+Before we proceed, you need to have Ubuntu Core [already running on your device](#0).
 
 
 ### Device Setup

--- a/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
@@ -22,17 +22,17 @@ duration: 1:00
 
 ### What you'll learn
 
-In this tutorial we will create a snap of an X11 application to act as the graphical user interface for an IoT or kiosk device. For the introduction to this tutorial series and the Mir display server please visit [here](tutorial/secure-ubuntu-kiosk).
+In this tutorial we will create a snap of an X11 application to act as the graphical user interface for an IoT or kiosk device. For the introduction to this tutorial series and the Mir display server please visit [here](/tutorial/secure-ubuntu-kiosk).
 
 X11 is a legacy protocol, it is known to be insecure, so we need to take steps to ensure it is secured correctly. To do this we shall embed an intermediary Xwayland server in the application snap and use snapd's infrastructure to maintain security.
 
 positive
 : The combination of Snap, the "mir-kiosk" Wayland server and Ubuntu Core ensures the reliability and security of any graphical embedded device application. 
 
-This tutorial assumes you are familiar with the material in [Make a Wayland-native Kiosk snap](tutorial/wayland-kiosk). In particular, techniques for debugging problems in your snap are not repeated here.
+This tutorial assumes you are familiar with the material in [Make a Wayland-native Kiosk snap](/tutorial/wayland-kiosk). In particular, techniques for debugging problems in your snap are not repeated here.
 
 negative
-: Depending on the toolkit your application is written in, it may work on the newer and more secure Wayland protocol. If so, the snapping process is simpler. To check, please read [this guide](tutorial/wayland-kiosk).
+: Depending on the toolkit your application is written in, it may work on the newer and more secure Wayland protocol. If so, the snapping process is simpler. To check, please read [this guide](/tutorial/wayland-kiosk).
 
 
 ### What you'll need
@@ -42,7 +42,7 @@ negative
 *   An Ubuntu desktop running any current release of Ubuntu or an Ubuntu Virtual Machine on another OS.
 *   A 'Target Device' from one of the following:
     *   **A device running [Ubuntu Core](https://www.ubuntu.com/core).**<br />
-[This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](https://tutorials.ubuntu.com/tutorial/create-your-own-core-image).
+[This guide](https://developer.ubuntu.com/core/get-started/installation-medias) shows you how to set up a supported device. If there's no supported image that fits your needs you can [create your own core image](/tutorial/create-your-own-core-image).
     *   **Using a VM**
 You don't have to have a physical "Target Device", you can follow the tutorial with Ubuntu Core in a VM. Install the ubuntu-core-vm snap:
 `sudo snap install --beta ubuntu-core-vm --devmode`
@@ -90,7 +90,7 @@ The Snap security framework then ensures this X11 server is private to the appli
 It may also be your application is written using X11 calls directly, in which case this guide is for you.
 
 positive
-: If your application is written using GTK3/4, Qt5 or SDL2, or another toolkit with native Wayland support, you should follow [this guide](tutorial/wayland-kiosk).
+: If your application is written using GTK3/4, Qt5 or SDL2, or another toolkit with native Wayland support, you should follow [this guide](/tutorial/wayland-kiosk).
 
 
 ## Introducing glxgears, Xwayland and i3

--- a/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/x11-kiosk.md
@@ -12,7 +12,7 @@ author: Gerry Boland <gerry.boland@canonical.com>
 ---
 
 
-# Make an X11-based Kiosk Snap
+# Make a X11-based Kiosk Snap
 
 
 ## Overview


### PR DESCRIPTION
## Done

- Fixed links back to tutorials in all ubuntu-kiosk tutorials
- Fixed x11-kiosk title

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)
- Check that the links in http://0.0.0.0:8016/tutorial/secure-ubuntu-kiosk#3 are working fine - linking to other tutorials