### PR TITLE
Fix command in web kiosk tutorial

### DIFF
--- a/tutorials/iot/ubuntu-kiosk/ubuntu-web-kiosk.md
+++ b/tutorials/iot/ubuntu-kiosk/ubuntu-web-kiosk.md
@@ -137,7 +137,7 @@ snap set chromium-mir-kiosk shownav=false
 
 
 ```bash
-snap set chromium-mir-kiosk url=["http://www.canonical.com","https://www.ubuntu.com"]
+snap set chromium-mir-kiosk 'url=["http://www.canonical.com","https://www.ubuntu.com"]'
 ```
 
 


### PR DESCRIPTION
Missing single quotes.

## Done

Fix command in web kiosk tutorial

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)