### PR TITLE
Fix typo in "create-a-usb-stick-on-windows.md"

### DIFF
--- a/tutorials/desktop/create-a-usb-stick-on-windows/create-a-usb-stick-on-windows.md
+++ b/tutorials/desktop/create-a-usb-stick-on-windows/create-a-usb-stick-on-windows.md
@@ -91,7 +91,7 @@ Leave all other parameters with their default values and click **START** to init
 ## Additional downloads
 Duration: 1:00
 
-You may be alerted that Refus requires additional files to complete writing the ISO.  If this dialog box appears, select **Yes** to continue.
+You may be alerted that Rufus requires additional files to complete writing the ISO.  If this dialog box appears, select **Yes** to continue.
 
 ![screenshot](./windows-rufus3-additional-downloads.png)
 


### PR DESCRIPTION
Rufus is misspelled Refus on line 94 of "create-a-usb-stick-on-windows.md"