### PR TITLE
Fix quoted version note in Create your first snap

### DIFF
--- a/tutorials/packaging/create-your-first-snap/create-your-first-snap.md
+++ b/tutorials/packaging/create-your-first-snap/create-your-first-snap.md
@@ -167,10 +167,7 @@ confinement: devmode
 
 positive
 : **Note:**
-The version is quoted ('`2.10`') because the version is a string, not a number. You could
-theoretically use a version string without numbers (like '`myfirstversion`'). This information is
-for user consumption only and doesn't require special ordering (e.g. ver1 > ver2) for an update to
-reach the user.
+Version information is for snap user consumption only, and has no effect on snap updates. It's defined within quotes, (`'2.10'`), because it needs to be a [YAML string](http://yaml.org/type/str.html) rather than a floating-point number. Using a string allows for non-numeric version details, such as '`myfirstversion`' or '`2.3-git`'.
 
 ### Adding a part
 


### PR DESCRIPTION
## Done
This patch mainly emphasizes the YAML data types and the exact reason to
add the quoting, so the readers will get the idea logically.

Misc. changes:

* Replace ('`2.10`') with (`'2.10'`) as the single quotes are part of the
code.
* Add code formatting to the `version` keyword
* Drop the forced line wrapping as the rendered result is clearly subject to the
line endings

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>

## QA

- [x] Check out this feature branch
- [x] Run the site using the command `./run serve`
- [x] View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)

## Screenshots

![default](https://user-images.githubusercontent.com/13408130/47481018-eed3fe80-d864-11e8-9efc-7af37d5c88df.png)

