### PR TITLE
Drop invalid code in Create your first snap

### DIFF
--- a/tutorials/packaging/create-your-first-snap/create-your-first-snap.md
+++ b/tutorials/packaging/create-your-first-snap/create-your-first-snap.md
@@ -370,7 +370,7 @@ apps:
 parts:
   gnu-hello:
     source: http://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz
-    plugin: autotools command: bin/hello
+    plugin: autotools
 ```
 
 ### Iterating over your snap


### PR DESCRIPTION

## Done
This patch drops invalid code from the example recipe, seems to be a trivial copy & paste error.

## QA

- [x] Check out this feature branch
- [x] Run the site using the command `./run serve`
- [x] View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)
