### PR TITLE
Create your first snap: Fix system snap directory

### DIFF
--- a/tutorials/packaging/create-your-first-snap/create-your-first-snap.md
+++ b/tutorials/packaging/create-your-first-snap/create-your-first-snap.md
@@ -482,7 +482,7 @@ have the command condensed to `hello`.
 Our snap will thus result in two binaries being shipped: `hello` and `hello.bash`.
 
 Note that we set `bash` as the command parameter, and not `bin/bash` relative to the system snap
-directory (`$SNAP=/snap`) as we did for `hello`. Both are equally valid because `snapcraft` and
+directory (`$SNAP=/snap/hello/current`) as we did for `hello`. Both are equally valid because `snapcraft` and
 `snapd` create a small wrapper around your executable command which sets some environment
 variables. Technically, `$SNAP/bin` will be prepended to your `$PATH` for this snap. This avoids
 the need to set the path explicitly. This topic will be touched upon in upcoming sections.


### PR DESCRIPTION
## Done

* Fixes the wrong value of the $SNAP environment variable at https://tutorials.ubuntu.com/tutorial/create-your-first-snap#4

## QA

- [x] Check out this feature branch
- [x] Run the site using the command `./run serve`
- [x] View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)

## Screenshots
![image](https://user-images.githubusercontent.com/13408130/47607116-57320400-da4e-11e8-8267-f7e8bd9ce286.png)
