### PR TITLE
Update create-custom-lxd-images.md

### DIFF
--- a/tutorials/containers/create-custom-lxd-images/create-custom-lxd-images.md
+++ b/tutorials/containers/create-custom-lxd-images/create-custom-lxd-images.md
@@ -76,16 +76,16 @@ sudo tar -cvzf rootfs.tar.gz -C /tmp/sid-lxd .
 ## Creating a metadata file
 Duration: 2:00
 
-The `medatata.yaml` file describes things like image creation date, name, architecture and description. To create an LXD image, we need to provide such a file. Here's an example of how simple metadata file should look:
+The `metadata.yaml` file describes things like image creation date, name, architecture and description. To create an LXD image, we need to provide such a file. Here's an example of how simple metadata file should look:
 
 ```
 architecture: "x86_64"
 creation_date: 1458040200 # To get current date in Unix time, use `date +%s` command
 properties:
- architecture: "x86_64"
-  description: "Debian Unstable (sid) with preconfigured Node.js repository (20171227)"
-   os: "debian"
-    release: "sid"
+architecture: "x86_64"
+description: "Debian Unstable (sid) with preconfigured Node.js repository (20171227)"
+os: "debian"
+release: "sid"
 ```
 
 ### Creating a tarball from the metadata file


### PR DESCRIPTION
Corrected typo and indentation in metadata file (metadata.yaml) creation.
The previous description caused an error in LXC image importing.

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8016/](http://0.0.0.0:8016/)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

[List of links to Github issues/bugs and cards if needed - e.g. `Fixes #1`]

## Screenshots

[if relevant, include a screenshot]
