### PR TITLE
Fix typo

### DIFF
--- a/tutorials/containers/create-custom-lxd-images/create-custom-lxd-images.md
+++ b/tutorials/containers/create-custom-lxd-images/create-custom-lxd-images.md
@@ -13,7 +13,7 @@ author: Marcin Mikołajczak <me@m4sk.in>
 
 # Creating custom LXD images
 
-## Overwiew
+## Overview
 Duration: 1:00
 
 [LXD](https://linuxcontainers.org/lxd) is a container hypervisor providing a ReST API to manage LXC containers.


### PR DESCRIPTION
## Done

- fixed single letter typo on tutorials.ubuntu.com/tutorials/containers/create-custom-lxd-images/create-custom-lxd-images.md

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/tutorial/create-custom-lxd-images#0](http://0.0.0.0:8016/tutorial/create-custom-lxd-images#0)
- See that 'Overview' is spelled correctly

## Issue / Card

Fixes #905